### PR TITLE
fix: queue socket-timeout spam + confidence-gate crash (2 production bugs)

### DIFF
--- a/app/core/confidence.py
+++ b/app/core/confidence.py
@@ -4,9 +4,14 @@ V3: Per-action confidence scoring.
 Low confidence = suggest only, don't auto-apply.
 """
 
-from app.core.logger import get_logger
+from app.core.logger import EventLogger
 
-log = get_logger(__name__)
+# get_logger() returns a plain stdlib logging.Logger, which does not accept
+# arbitrary keyword args (action=, score=, ...) — that raises
+# "TypeError: Logger._log() got an unexpected keyword argument". EventLogger
+# is this codebase's structured-logging wrapper (see app/core/logger.py) and
+# is what every log.info(msg, key=val, ...) call site below actually needs.
+log = EventLogger("confidence")
 
 # Default thresholds per action (0.0 - 1.0)
 DEFAULT_THRESHOLDS = {

--- a/app/core/confidence.py
+++ b/app/core/confidence.py
@@ -6,11 +6,8 @@ Low confidence = suggest only, don't auto-apply.
 
 from app.core.logger import EventLogger
 
-# get_logger() returns a plain stdlib logging.Logger, which does not accept
-# arbitrary keyword args (action=, score=, ...) — that raises
-# "TypeError: Logger._log() got an unexpected keyword argument". EventLogger
-# is this codebase's structured-logging wrapper (see app/core/logger.py) and
-# is what every log.info(msg, key=val, ...) call site below actually needs.
+# EventLogger (not get_logger/stdlib Logger) because evaluate() below logs
+# structured kwargs (action=, score=, ...) that a plain Logger rejects.
 log = EventLogger("confidence")
 
 # Default thresholds per action (0.0 - 1.0)

--- a/app/core/event_queue.py
+++ b/app/core/event_queue.py
@@ -59,6 +59,9 @@ import time
 from typing import Callable
 
 from app.core.metrics import metrics
+
+# get_redis_blocking() (not get_redis()) is required for the BLMOVE call in
+# _consume_once() -- see redis_client.BLOCKING_SOCKET_TIMEOUT for why.
 from app.core.redis_client import get_redis, get_redis_blocking, is_redis_available
 
 log = logging.getLogger(__name__)

--- a/app/core/event_queue.py
+++ b/app/core/event_queue.py
@@ -35,6 +35,18 @@ FAILURE MODES (all explicit, all observable via metrics)
   Queue full       → FULL → 503 → GitHub redelivers (up to ~1h of retries).
   Handler crashes  → event requeued once (attempts+1), then dead-lettered.
   Process killed   → events in evq:processing requeued on next boot.
+
+FIXED: consumers were logging a spurious "queue.consumer_error ... Timeout
+  reading from socket" on nearly every idle poll cycle in production. Root
+  cause: BLMOVE's own blocking wait (BLOCK_SECONDS=5) was racing the shared
+  Redis client's socket read timeout (also 5s, in redis_client.py) — when the
+  server legitimately blocked for the full 5s waiting for new work, the
+  client's own read timeout fired at essentially the same instant, so nearly
+  every idle poll raised a false error. _consume_once() now uses
+  get_redis_blocking() (redis_client.py), a dedicated connection with a
+  generous 30s socket timeout, for exactly this reason. Fast (non-blocking)
+  operations elsewhere keep using get_redis()'s tight 5s timeout so they still
+  fail fast if Redis is genuinely down.
 """
 
 from __future__ import annotations
@@ -47,7 +59,7 @@ import time
 from typing import Callable
 
 from app.core.metrics import metrics
-from app.core.redis_client import get_redis, is_redis_available
+from app.core.redis_client import get_redis, get_redis_blocking, is_redis_available
 
 log = logging.getLogger(__name__)
 
@@ -170,8 +182,14 @@ def _consume_once(handler: Callable[[str, dict, str], None]) -> bool:
     """
     One consume step: BLMOVE pending→processing, run handler, LREM processing.
     Returns True if an event was processed. Split out of the loop for tests.
+
+    Uses get_redis_blocking() (generous socket timeout) rather than get_redis()
+    (tight 5s timeout) for the BLMOVE call: a client socket timeout equal to or
+    below BLOCK_SECONDS races the server's own blocking wait and raises a
+    spurious "Timeout reading from socket" error on nearly every idle poll —
+    see redis_client.BLOCKING_SOCKET_TIMEOUT for the full explanation.
     """
-    r = get_redis()
+    r = get_redis_blocking()
     # LPUSH producer + RIGHT-pop consumer = FIFO ordering
     raw = r.blmove(PENDING_KEY, PROCESSING_KEY, timeout=BLOCK_SECONDS, src="RIGHT", dest="LEFT")
     if raw is None:

--- a/app/core/redis_client.py
+++ b/app/core/redis_client.py
@@ -19,7 +19,10 @@ _IS_PRODUCTION = (
 
 _pool: redis_lib.ConnectionPool | None = None
 _client = None
-_client_lock = threading.Lock()
+# RLock (not Lock): get_redis_blocking()'s no-REDIS_URL fallback calls get_redis()
+# from inside its own `with _client_lock:` block. A plain Lock would deadlock the
+# same thread against itself there; RLock allows that same-thread reentry.
+_client_lock = threading.RLock()
 
 
 def get_redis() -> "redis_lib.Redis | _FakeRedis":

--- a/app/core/redis_client.py
+++ b/app/core/redis_client.py
@@ -75,6 +75,70 @@ def get_redis() -> "redis_lib.Redis | _FakeRedis":
         return _client
 
 
+# Blocking commands (BLPOP/BRPOP/BLMOVE) hold the connection open server-side
+# for up to their own `timeout` argument while waiting for data. If the
+# client's socket read timeout is <= that duration, the client can time out
+# client-side while the server is still legitimately blocking — a classic
+# redis-py footgun that produces spurious "Timeout reading from socket" errors
+# on essentially every idle poll. This must stay comfortably larger than the
+# longest blocking-command timeout used anywhere in the app (currently
+# app.core.event_queue.BLOCK_SECONDS = 5s).
+BLOCKING_SOCKET_TIMEOUT = 30
+
+_blocking_pool: redis_lib.ConnectionPool | None = None
+_blocking_client = None
+
+
+def get_redis_blocking() -> "redis_lib.Redis | _FakeRedis":
+    """
+    Like get_redis(), but backed by a connection pool with a generous socket
+    timeout suitable for blocking commands. Use this for BLPOP/BRPOP/BLMOVE;
+    use get_redis() for everything else so fast operations still fail fast
+    when Redis is genuinely down.
+
+    Falls back to get_redis()'s own in-memory stub when REDIS_URL is unset,
+    so dev/test callers share the identical fake store.
+    """
+    global _blocking_pool, _blocking_client
+
+    if _blocking_client is not None:
+        return _blocking_client
+
+    with _client_lock:
+        if _blocking_client is not None:
+            return _blocking_client
+
+        redis_url = os.environ.get("REDIS_URL", "")
+        if not redis_url:
+            _blocking_client = get_redis()
+            return _blocking_client
+
+        try:
+            _blocking_pool = redis_lib.ConnectionPool.from_url(
+                redis_url,
+                max_connections=6,
+                socket_connect_timeout=5,
+                socket_timeout=BLOCKING_SOCKET_TIMEOUT,
+                retry_on_timeout=True,
+                decode_responses=True,
+            )
+            _blocking_client = redis_lib.Redis(connection_pool=_blocking_pool)
+            _blocking_client.ping()
+            log.info(f"redis.blocking_connected url={redis_url[:30]}...")
+        except Exception as e:
+            if _IS_PRODUCTION:
+                raise RuntimeError(
+                    f"Redis (blocking pool) connection failed in production: {e}. "
+                    "Check REDIS_URL and that the Redis service is running."
+                ) from e
+            log.warning(
+                f"Redis blocking-pool connection failed: {e} — using in-memory fallback (dev/test only)"
+            )
+            _blocking_client = _FakeRedis()
+
+        return _blocking_client
+
+
 def is_redis_available() -> bool:
     """Returns True if real Redis is connected (not in-memory fallback)."""
     try:
@@ -88,11 +152,13 @@ def is_redis_available() -> bool:
 
 
 def reset_client() -> None:
-    """Force-reset the singleton (tests only)."""
-    global _pool, _client
+    """Force-reset the singleton(s) (tests only)."""
+    global _pool, _client, _blocking_pool, _blocking_client
     with _client_lock:
         _pool = None
         _client = None
+        _blocking_pool = None
+        _blocking_client = None
 
 
 class _FakeRedis:

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -85,5 +85,5 @@ class TestConfidenceGate:
         with caplog.at_level(logging.INFO, logger="handler.confidence"):
             result = self.gate.evaluate("pr_title_rewrite", {"confidence": 0.9})
         assert result["auto_apply"] is True
-        assert any("confidence.evaluated" in r.message for r in caplog.records)
+        assert any("confidence.evaluated" in record.message for record in caplog.records)
 

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -3,6 +3,8 @@ Tests - tests/test_confidence.py
 V3: Unit tests for confidence scoring system.
 """
 
+import logging
+
 from app.core.confidence import ConfidenceGate, DEFAULT_THRESHOLDS
 
 
@@ -68,4 +70,20 @@ class TestConfidenceGate:
     def test_all_default_thresholds_are_valid(self):
         for action, threshold in DEFAULT_THRESHOLDS.items():
             assert 0.0 <= threshold <= 1.0, f"{action} threshold out of range"
+
+    def test_evaluate_logs_at_info_without_raising(self, caplog):
+        """
+        Regression guard: evaluate() logs via log.info("...", action=, score=,
+        auto_apply=, threshold=). A plain stdlib logging.Logger does not accept
+        arbitrary kwargs and raises TypeError -- but only once INFO-level
+        logging is actually enabled (Python short-circuits the kwargs check
+        when the level is disabled). This suite's conftest sets LOG_LEVEL=
+        WARNING globally, which is exactly why this bug shipped to production
+        (Render runs LOG_LEVEL=INFO) without ever failing a test. Force INFO
+        here so this test would have caught it.
+        """
+        with caplog.at_level(logging.INFO, logger="handler.confidence"):
+            result = self.gate.evaluate("pr_title_rewrite", {"confidence": 0.9})
+        assert result["auto_apply"] is True
+        assert any("confidence.evaluated" in r.message for r in caplog.records)
 

--- a/tests/test_event_queue.py
+++ b/tests/test_event_queue.py
@@ -17,6 +17,7 @@ from app.core.redis_client import _FakeRedis
 def fake_redis(monkeypatch):
     r = _FakeRedis()
     monkeypatch.setattr(eq, "get_redis", lambda: r)
+    monkeypatch.setattr(eq, "get_redis_blocking", lambda: r)
     monkeypatch.setattr(eq, "is_redis_available", lambda: True)
     return r
 

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -74,6 +74,77 @@ class TestSingleton:
         assert isinstance(r, rc._FakeRedis)
 
 
+class TestBlockingClient:
+    """
+    get_redis_blocking() backs BLPOP/BRPOP/BLMOVE callers with a generous
+    socket timeout. A client socket timeout <= the server-side blocking
+    `timeout` argument races the server's legitimate blocking wait and raises
+    spurious "Timeout reading from socket" errors on nearly every idle poll —
+    this is exactly the bug this dedicated client exists to avoid.
+    """
+
+    def test_blocking_timeout_exceeds_event_queue_block_seconds(self):
+        from app.core.event_queue import BLOCK_SECONDS
+
+        assert rc.BLOCKING_SOCKET_TIMEOUT > BLOCK_SECONDS, (
+            "the blocking client's socket timeout must stay comfortably larger "
+            "than any blocking command's server-side timeout, or the client "
+            "will race the server and raise spurious read-timeout errors"
+        )
+
+    def test_returns_same_instance_every_call(self):
+        r1 = rc.get_redis_blocking()
+        r2 = rc.get_redis_blocking()
+        assert r1 is r2
+
+    def test_no_redis_url_shares_get_redis_fake(self):
+        """In dev/test fallback, both getters must share one fake store."""
+        with patch.dict(os.environ, {"REDIS_URL": ""}):
+            rc.reset_client()
+            plain = rc.get_redis()
+            blocking = rc.get_redis_blocking()
+        assert plain is blocking
+        assert isinstance(blocking, rc._FakeRedis)
+
+    def test_connection_failure_falls_back_to_fake(self):
+        import redis as redis_lib
+        with patch.dict(os.environ, {"REDIS_URL": "redis://unreachable:9999/0"}):
+            rc.reset_client()
+            with patch.object(redis_lib.Redis, "ping", side_effect=Exception("refused")):
+                r = rc.get_redis_blocking()
+        assert isinstance(r, rc._FakeRedis)
+
+    def test_reset_client_clears_blocking_singleton_too(self):
+        with patch.dict(os.environ, {"REDIS_URL": ""}):
+            rc.reset_client()
+            r1 = rc.get_redis_blocking()
+            rc.reset_client()
+            r2 = rc.get_redis_blocking()
+        assert r1 is not r2
+
+    def test_real_connection_uses_generous_socket_timeout(self):
+        """The pool actually created for a real Redis URL uses the generous timeout,
+        not the tight 5s default used by get_redis()."""
+        import redis as redis_lib
+
+        captured = {}
+        real_from_url = redis_lib.ConnectionPool.from_url
+
+        def spy_from_url(url, **kwargs):
+            captured.update(kwargs)
+            return real_from_url(url, **kwargs)
+
+        with patch.dict(os.environ, {"REDIS_URL": "redis://unreachable:9999/0"}):
+            rc.reset_client()
+            with (
+                patch.object(redis_lib.ConnectionPool, "from_url", side_effect=spy_from_url),
+                patch.object(redis_lib.Redis, "ping", side_effect=Exception("refused")),
+            ):
+                rc.get_redis_blocking()
+
+        assert captured.get("socket_timeout") == rc.BLOCKING_SOCKET_TIMEOUT
+
+
 class TestFakeRedis:
 
     def setup_method(self):


### PR DESCRIPTION
Two real production bugs found in live logs, fixed:

**1. queue.consumer_error socket-timeout spam** — BLMOVE blocks server-side for BLOCK_SECONDS=5s; the shared Redis client's socket_timeout was also 5s, so nearly every idle poll raced the server's legitimate wait and logged a spurious error every ~10s. Fixed with a dedicated get_redis_blocking() client (30s socket timeout) for blocking commands only.

**2. ConfidenceGate crashed pull_request handling** — `TypeError: Logger._log() got an unexpected keyword argument 'action'`. confidence.py used a raw stdlib logger but called it with structured kwargs (only this codebase's EventLogger wrapper supports that). Existing tests never caught it because conftest sets LOG_LEVEL=WARNING, which short-circuits kwarg validation for INFO calls — added a test that forces INFO explicitly.

Both fixed, tests added, verifying via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)