### PR TITLE
feat: v6.2.0 — inline PR reviews, AI evals, quality floor, hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "github-autopilot",
       "description": "Call GitHub Autopilot's AI tools (analyze PR, fix issue, scan secrets, repo health) from Claude Code via MCP.",
-      "version": "6.1.1",
+      "version": "6.2.0",
       "source": "./plugin",
       "homepage": "https://github.com/Shweta-Mishra-ai/github-autopilot",
       "license": "MIT",

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ MCP_API_KEY=                      # REQUIRED. MCP endpoint fails closed (503) if
 METRICS_AUTH_TOKEN=               # Any strong random string for /metrics endpoint
 
 # ── Optional ──────────────────────────────────────────────────────────────────
+MCP_API_KEYS=                      # Named keys "laptop:tok1,ci:tok2" — per-client revocation + attributable mcp.audit log lines. Combinable with MCP_API_KEY (label "default").
 MCP_ALLOWED_INSTALLATIONS=         # Comma-separated GitHub App installation IDs the MCP tools may act on. Unset = allow all (single-tenant).
 REDIS_URL=redis://localhost:6379/0 # Leave blank for in-memory fallback (dev only)
 QDRANT_URL=                        # Qdrant Cloud URL for code embedding search
@@ -26,6 +27,12 @@ PORT=5000
 EVENT_QUEUE_CONSUMERS=2
 # Bounded queue length — beyond this webhooks get 503 (GitHub retries).
 EVENT_QUEUE_MAX_LEN=200
+
+# ── AI quality (V6.2) ─────────────────────────────────────────────────────
+# LLM_QUALITY_FLOOR=high  # reviews/fixes REFUSE to run on a basic-tier model
+#                         # (Groq 8B / OpenRouter) instead of degrading silently.
+#                         # Fast tasks (labels, commit lint) are unaffected.
+# Every posted comment now discloses which model produced it.
 
 # ── Local LLM / privacy (V6) ─────────────────────────────────────────────
 # Run inference on hardware you control so source code never leaves your infra.

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,51 @@
+# .github/workflows/evals.yml
+# AI-output quality evals — manual trigger only (spends real provider quota).
+# Requires the GROQ_API_KEY repository secret. See evals/README.md.
+
+name: Evals
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Which eval set"
+        type: choice
+        options: [all, fix, review]
+        default: all
+      min_pass_rate:
+        description: "Fail below this pass rate"
+        default: "0.7"
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    name: AI output evals
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run evals
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_APP_ID: "99999"
+          GITHUB_PRIVATE_KEY: ""
+          GITHUB_WEBHOOK_SECRET: "eval-run-secret-32chars-long-abc!"
+          MCP_API_KEY: "eval-run-mcp-key"
+          LOG_FORMAT: "text"
+        run: |
+          python -m evals.run \
+            --task "${{ inputs.task }}" \
+            --min-pass-rate "${{ inputs.min_pass_rate }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,17 @@ pytest --cov=app tests/
 
 Tests run in full isolation — no network access required.
 
+### AI output evals
+
+The unit suite tests the plumbing; [`evals/`](evals/) tests the AI output
+itself (planted bugs, must-mention checks) through the real code paths.
+Run them before merging any change to prompts, provider order, or
+sanitization — they need a real `GROQ_API_KEY` and spend quota:
+
+```bash
+python -m evals.run
+```
+
 ---
 
 ## Good First Issues

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 **Your repository's AI co-pilot. Fix bugs, review PRs, scan secrets — from a single comment.**
 
+**The self-hosted one**: runs on your own free-tier infra, and in
+[local-LLM mode](#private-mode--keep-code-on-your-own-hardware) your code
+**never leaves your hardware** — the private-repo alternative to SaaS review bots.
+
 [![CI](https://github.com/Shweta-Mishra-ai/github-autopilot/actions/workflows/ci.yml/badge.svg)](https://github.com/Shweta-Mishra-ai/github-autopilot/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](https://python.org)
 [![Tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FShweta-Mishra-ai%2Fgithub-autopilot%2Fbadges%2Ftests.json)](https://github.com/Shweta-Mishra-ai/github-autopilot/actions/workflows/ci.yml)
@@ -15,7 +19,9 @@
 [![Deploy to Render](https://img.shields.io/badge/deploy-Render-46E3B7?logo=render&logoColor=white)](https://render.com/deploy)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-db61a2?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Shweta-Mishra-ai)
 
-<img src="assets/demo.svg" alt="Demo: /fix command in a GitHub issue, bot replies with root cause, fix and test in 4.2 seconds" width="720"/>
+<img src="assets/demo.svg" alt="Illustration: /fix command in a GitHub issue, bot replies with root cause, fix and test" width="720"/>
+
+<sub>*Simulated output for illustration — see the [eval suite](evals/) for measured behaviour.*</sub>
 
 </div>
 
@@ -27,11 +33,13 @@
 |---|---|
 | ⚡ **26 slash commands** | `/fix` `/security` `/merge` `/autofix` `/rollback` … right in issue/PR comments |
 | 🛡️ **Safety-first automation** | Confidence gates, guardrails, human-in-the-loop `/apply`, maintainer-only permissions |
-| 🔁 **Durable event queue** | Webhooks parked in Redis, survive restarts & deploys — no event ever silently lost |
+| 🔁 **Durable event queue** | Webhooks parked in Redis — survive restarts, deploys and crashes; if Redis itself dies, degrades to best-effort in-process dispatch (and says so in the logs) |
 | 🧠 **5-provider AI failover** | Groq 70B → Groq 8B → Gemini → OpenRouter, with per-provider circuit breakers |
 | 🔒 **Local-LLM privacy mode** | Run on your own Ollama — set `LLM_LOCAL_ONLY=1` and code **never** leaves your infra |
 | 🧩 **Private repo memory** | Learns your repo's fixes & decisions; sensitive context stays local, [encrypted backup](docs/ai-system/memory.md) for durability |
 | 🔐 **Security scanning** | Secret detection on **every push to every branch**, dependency CVE checks |
+| 📍 **Inline PR reviews** | Findings land as line-anchored review comments with committable suggestions — not a wall-of-text comment |
+| 📏 **Honest AI output** | Every comment discloses which model wrote it; optional [quality floor](#changelog) refuses to degrade reviews to a small model; [measured by evals](evals/), not vibes |
 | 🔌 **MCP server built in** | Call Autopilot tools from Claude Code, Cursor, or Codex — [setup guide](docs/mcp-setup.md) |
 | 📊 **Live ops dashboard** | `/dashboard` — queue depth, event throughput, provider circuit-breakers, thread pool. Zero build, no CDN |
 | 💸 **Runs on free tier** | Render free web service + free Redis. $0/month |
@@ -74,7 +82,7 @@ Install the GitHub App on your repos, then:
 
 ```bash
 curl https://github-autopilot-1.onrender.com/ping
-# → {"status": "ok", "version": "6.1.1"}
+# → {"status": "ok", "version": "6.2.0"}
 ```
 
 > **Cold starts** — the demo instance runs on Render's free tier. A scheduled
@@ -280,6 +288,14 @@ Found a vulnerability? Please email rather than opening a public issue.
 ---
 
 ## Changelog
+
+### V6.2.0 — 2026-07-11
+- **Inline PR reviews**: findings now post as a real GitHub Review with line-anchored comments, snapped onto actual diff lines, with committable ```suggestion blocks for safe single-line fixes. Automatic fallback to the classic issue comment if the Reviews API rejects a payload — a mapping bug can never lose a review.
+- **AI evals** ([evals/](evals/)): golden issues + PR diffs with planted bugs (SQL injection, hardcoded secret, N+1, path traversal, plus a clean-diff over-flagging check), pushed through the *real* production code paths and scored deterministically. Manual `Evals` workflow in Actions.
+- **Model disclosure**: every bot comment states which model produced it. **Quality floor** (`LLM_QUALITY_FLOOR=high`): reviews/fixes refuse to run on a basic-tier model instead of silently degrading to 8B.
+- **Learning loop finally wired** (shipped unit-tested-but-unused in V6.0): `/apply` and merging a bot autofix branch now record acceptance; future `/fix` prompts inject the learned repo conventions.
+- **Command rate limit enforced during Redis outages** (was fail-open) via a bounded in-memory window. **MCP named API keys** (`MCP_API_KEYS=laptop:tok1,ci:tok2`) with per-client revocation and an attributable audit log. **Redis memory watermark** on `/health` (the 25MB free tier fails writes when full — now visible before it bites).
+- Honesty pass: durability claim corrected (Redis-down fallback is best-effort and now says so), demo labeled as simulated, `/` endpoint no longer reports the pre-rename app name.
 
 ### V6.1.1 — 2026-07-10
 - **Honest badges**: the "tests: N passing" badge is now generated by CI itself — a `badges` job counts the passes from a real run on `main` and publishes the number; it can no longer drift from reality. New **Server Health** badge backed by a scheduled production ping.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,4 +2,4 @@
 
 # Single source of truth for the application version.
 # server.py, app/mcp/mcp_server.py, and pyproject.toml all reference this.
-__version__ = "6.1.1"
+__version__ = "6.2.0"

--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -65,6 +65,30 @@ COST_PER_1K = {
     "ollama": 0.0,  # local — free and private
 }
 
+# Quality tiers for the LLM_QUALITY_FLOOR guard. "basic" providers are fine
+# for fast tasks (labels, lint) but produce visibly weaker code reviews/fixes.
+# Ollama counts as "high": running local is an explicit operator choice.
+PROVIDER_TIER = {
+    "groq_70b": "high",
+    "gemini": "high",
+    "ollama": "high",
+    "groq_8b": "basic",
+    "openrouter": "basic",
+}
+
+# Task types where output quality is the product (reviews, fixes, analyses).
+QUALITY_SENSITIVE_TASK_TYPES = {"standard", "deep", "long"}
+
+
+def _quality_floor_active() -> bool:
+    """
+    LLM_QUALITY_FLOOR=high → quality-sensitive tasks refuse to run on a
+    basic-tier provider instead of silently degrading. Users see an honest
+    "providers down, retry later" rather than an 8B model reviewing their
+    code with no disclosure. Fast tasks (labels, commit lint) are unaffected.
+    """
+    return os.environ.get("LLM_QUALITY_FLOOR", "").strip().lower() == "high"
+
 
 class LLMRouter:
     def __init__(self):
@@ -217,6 +241,8 @@ class LLMRouter:
             raise AllProvidersDown()
 
         # Standard / Deep → 70B first
+        floor = _quality_floor_active() and task_type in QUALITY_SENSITIVE_TASK_TYPES
+
         pct_70b = self._usage_pct("groq_70b")
         if get_breaker("groq_70b").is_available() and pct_70b < 0.80:
             return self._groq_70b
@@ -224,12 +250,20 @@ class LLMRouter:
         if pct_70b >= 0.80:
             log.warning(f"router.groq_70b_high_usage pct={pct_70b:.0%} task={task}")
 
-        if task_type == "standard" and get_breaker("groq_8b").is_available():
+        if task_type == "standard" and not floor and get_breaker("groq_8b").is_available():
             return self._groq_8b
 
         g = self._get_gemini()
         if g and get_breaker("gemini").is_available():
             return g
+
+        if floor:
+            # Only basic-tier providers remain. Refuse honestly instead of
+            # letting an 8B model review code with no disclosure.
+            log.warning(
+                f"router.quality_floor_refusal task={task} — no high-tier provider available"
+            )
+            raise AllProvidersDown()
 
         if get_breaker("groq_8b").is_available():
             return self._groq_8b
@@ -281,7 +315,7 @@ class LLMRouter:
         if meta.error:
             log.warning(f"router.primary_failed provider={meta.provider} error={meta.error}")
             fallback = self._try_fallback(
-                system, user, max_tokens, temperature, timeout, meta.provider
+                system, user, max_tokens, temperature, timeout, meta.provider, task
             )
             if fallback:
                 result, meta = fallback
@@ -306,7 +340,9 @@ class LLMRouter:
         text, meta = provider.ask_text(system, user, max_tokens, timeout)
 
         if meta.error:
-            fallback = self._try_fallback_text(system, user, max_tokens, timeout, meta.provider)
+            fallback = self._try_fallback_text(
+                system, user, max_tokens, timeout, meta.provider, task
+            )
             if fallback:
                 text, meta = fallback
             else:
@@ -315,21 +351,34 @@ class LLMRouter:
         self._log_and_track(task, meta)
         return text, meta
 
-    def _fallback_candidates(self) -> list:
+    def _fallback_candidates(self, task: str = "standard") -> list:
         """
         Provider order for fallback. In LLM_LOCAL_ONLY mode the list contains
         ONLY Ollama — cloud providers are never appended, so a local failure
         can never silently leak code to a cloud API.
+
+        When LLM_QUALITY_FLOOR=high, basic-tier providers are excluded for
+        quality-sensitive tasks — the same guarantee _select_provider gives
+        must hold on the fallback path too.
         """
         if self._local_only():
             return [self._get_ollama()]
         candidates = [self._groq_70b, self._groq_8b, self._get_gemini(), self._get_openrouter()]
         if self._prefer_local():
             candidates.insert(0, self._get_ollama())
+        task_type = TASK_MAP.get(task, "standard")
+        if _quality_floor_active() and task_type in QUALITY_SENSITIVE_TASK_TYPES:
+            candidates = [
+                p
+                for p in candidates
+                if p is not None and PROVIDER_TIER.get(p.provider_key, "basic") == "high"
+            ]
         return candidates
 
-    def _try_fallback(self, system, user, max_tokens, temperature, timeout, failed_key):
-        candidates = self._fallback_candidates()
+    def _try_fallback(
+        self, system, user, max_tokens, temperature, timeout, failed_key, task="standard"
+    ):
+        candidates = self._fallback_candidates(task)
         for p in candidates:
             if p is None or p.provider_key == failed_key:
                 continue
@@ -341,8 +390,8 @@ class LLMRouter:
                 return result, meta
         return None
 
-    def _try_fallback_text(self, system, user, max_tokens, timeout, failed_key):
-        candidates = self._fallback_candidates()
+    def _try_fallback_text(self, system, user, max_tokens, timeout, failed_key, task="standard"):
+        candidates = self._fallback_candidates(task)
         for p in candidates:
             if p is None or p.provider_key == failed_key:
                 continue
@@ -355,6 +404,10 @@ class LLMRouter:
         return None
 
     def _log_and_track(self, task: str, meta: LLMResponse):
+        # Remembered per-thread so comment assembly can disclose which model
+        # actually produced the output (handlers run one event per thread).
+        _last_call.provider = meta.provider
+        _last_call.model = meta.model
         cost_est = (meta.total_tokens / 1000) * COST_PER_1K.get(meta.provider, 0)
         log.info(
             f"router.call task={task} provider={meta.provider} "
@@ -460,6 +513,29 @@ class LLMRouter:
                 "openrouter": bool(os.environ.get("OPENROUTER_API_KEY")),
             },
         }
+
+
+# Per-thread record of the last completed LLM call (provider + model).
+_last_call = threading.local()
+
+
+def reset_last_call() -> None:
+    """Clear this thread's model record (call at the start of each event)."""
+    _last_call.provider = ""
+    _last_call.model = ""
+
+
+def last_model_disclosure() -> str:
+    """
+    Human-readable "which model wrote this" line for bot output, from the
+    last completed LLM call on this thread. Empty string when nothing has
+    run yet — callers append it blindly.
+    """
+    provider = getattr(_last_call, "provider", "")
+    model = getattr(_last_call, "model", "")
+    if not provider:
+        return ""
+    return f" · model: `{model or provider}`"
 
 
 # Module-level singleton — thread-safe via instance locks above

--- a/app/core/redis_client.py
+++ b/app/core/redis_client.py
@@ -154,6 +154,44 @@ def is_redis_available() -> bool:
         return False
 
 
+REDIS_MEMORY_WARN_PCT = int(os.environ.get("REDIS_MEMORY_WARN_PCT", "80"))
+
+
+def redis_memory_status() -> dict:
+    """
+    Memory watermark for the shared Redis budget.
+
+    On the 25MB free tier the event queue, idempotency keys, rate limits,
+    analytics and the repo-memory brain all share one `noeviction` instance:
+    when it fills, WRITES FAIL (queue 503s, dedup breaks). This surfaces the
+    watermark on /health so the operator sees it before it bites.
+
+    Returns {level, used_bytes, max_bytes, used_pct}; level is
+    ok | warn (≥REDIS_MEMORY_WARN_PCT%) | unknown (fake/unreachable/no limit).
+    """
+    try:
+        client = get_redis()
+        if isinstance(client, _FakeRedis):
+            return {"level": "unknown", "used_bytes": None, "max_bytes": None, "used_pct": None}
+        info = client.info("memory")
+        used = int(info.get("used_memory", 0))
+        maxm = int(info.get("maxmemory", 0))
+        if maxm <= 0:
+            # No server-side cap configured — report usage, can't compute %.
+            return {"level": "ok", "used_bytes": used, "max_bytes": None, "used_pct": None}
+        pct = round(used * 100.0 / maxm, 1)
+        level = "warn" if pct >= REDIS_MEMORY_WARN_PCT else "ok"
+        if level == "warn":
+            log.warning(
+                f"redis.memory_watermark used={used} max={maxm} pct={pct}% "
+                f"(warn threshold {REDIS_MEMORY_WARN_PCT}%) — writes fail when full (noeviction)"
+            )
+        return {"level": level, "used_bytes": used, "max_bytes": maxm, "used_pct": pct}
+    except Exception as e:
+        log.debug(f"redis.memory_status_unavailable: {e}")
+        return {"level": "unknown", "used_bytes": None, "max_bytes": None, "used_pct": None}
+
+
 def reset_client() -> None:
     """Force-reset the singleton(s) (tests only)."""
     global _pool, _client, _blocking_pool, _blocking_client

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -17,6 +17,7 @@ DASHBOARD_HTML = """<!doctype html>
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="robots" content="noindex"/>
 <title>GitHub Autopilot — Ops</title>
 <style>
   :root {

--- a/app/github/patch_parser.py
+++ b/app/github/patch_parser.py
@@ -1,0 +1,123 @@
+"""
+app/github/patch_parser.py — V6.2
+Pure helpers for mapping AI review findings onto GitHub diff positions.
+
+GitHub's Pulls Review API only accepts inline comments on lines that appear
+in the diff (added or context lines of the NEW file version). The AI returns
+approximate line references ("~42", "42-45", "around line 40"); these helpers
+parse the unified-diff patch GitHub already gives us per file, enumerate the
+line numbers a comment may legally anchor to, and snap an approximate target
+to the nearest legal line.
+
+No network, no state — deliberately unit-test friendly.
+"""
+
+from __future__ import annotations
+
+import re
+
+# New-file line numbers a PR review comment may anchor to, mapped to
+# (line_content, is_added). Context lines are commentable but a committable
+# ``suggestion`` block only makes sense on an added line.
+CommentableLines = dict[int, tuple[str, bool]]
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def commentable_lines(patch: str) -> CommentableLines:
+    """
+    Parse a unified-diff `patch` (as returned by GitHub's files API) into
+    {new_file_line_number: (content, is_added)} for every line that exists in
+    the new file version (added '+' and context ' ' lines; '-' lines belong
+    to the old version and are skipped).
+    """
+    lines: CommentableLines = {}
+    if not patch:
+        return lines
+    new_ln = 0
+    in_hunk = False
+    for raw in patch.splitlines():
+        m = _HUNK_RE.match(raw)
+        if m:
+            new_ln = int(m.group(1))
+            in_hunk = True
+            continue
+        if not in_hunk:
+            continue
+        if raw.startswith("+"):
+            lines[new_ln] = (raw[1:], True)
+            new_ln += 1
+        elif raw.startswith("-"):
+            continue  # old-version line — not commentable, no new-line advance
+        elif raw.startswith("\\"):
+            continue  # "\ No newline at end of file"
+        else:
+            # context line (starts with ' ' or is empty)
+            lines[new_ln] = (raw[1:] if raw.startswith(" ") else raw, False)
+            new_ln += 1
+    return lines
+
+
+def parse_line_ref(ref) -> int | None:
+    """
+    Extract the first line number from an AI line reference.
+    Accepts ints or strings like "42", "~42", "42-45", "around line 40".
+    Returns None when no number is present ("?", "", None).
+    """
+    if isinstance(ref, int):
+        return ref if ref > 0 else None
+    if not ref:
+        return None
+    m = re.search(r"\d+", str(ref))
+    return int(m.group()) if m else None
+
+
+def nearest_commentable(
+    target: int | None, lines: CommentableLines, max_distance: int = 5
+) -> int | None:
+    """
+    Snap `target` to the nearest legally-commentable line within
+    `max_distance`. Prefers added lines over context lines on a distance tie
+    (the finding is almost certainly about the new code). Returns None when
+    nothing is close enough — the caller should keep that finding in the
+    summary body instead of guessing.
+    """
+    if target is None or not lines:
+        return None
+    best: int | None = None
+    best_key: tuple[int, int] | None = None
+    for ln, (_content, is_added) in lines.items():
+        dist = abs(ln - target)
+        if dist > max_distance:
+            continue
+        key = (dist, 0 if is_added else 1)
+        if best_key is None or key < best_key:
+            best, best_key = ln, key
+    return best
+
+
+def make_suggestion_block(fix: str, anchor_line: int, lines: CommentableLines) -> str:
+    """
+    Return a committable ```suggestion block for `fix`, or "" when a
+    suggestion would be unsafe. GitHub applies a suggestion by REPLACING the
+    anchored line, so we only emit one when:
+      - the fix is a single line of code (no newlines, sane length),
+      - the anchor is an ADDED line (suggesting over unchanged context is
+        usually wrong), and
+      - the fix actually differs from the current line content.
+    Anything else belongs in a normal fenced code block.
+    """
+    if not fix or "\n" in fix or len(fix) > 200:
+        return ""
+    entry = lines.get(anchor_line)
+    if entry is None:
+        return ""
+    content, is_added = entry
+    if not is_added or fix.strip() == content.strip():
+        return ""
+    # Preserve the original line's indentation when the model dropped it.
+    if not fix[:1].isspace() and content[: len(content) - len(content.lstrip())]:
+        indent = content[: len(content) - len(content.lstrip())]
+        if not fix.startswith(indent):
+            fix = indent + fix.lstrip()
+    return f"```suggestion\n{fix}\n```"

--- a/app/handlers/comments/dispatcher.py
+++ b/app/handlers/comments/dispatcher.py
@@ -6,12 +6,20 @@ Command extraction, rate limiting, and provider-down handling.
 from __future__ import annotations
 
 import re
+import threading
 import time
 import logging
 
 from .constants import ALL_COMMANDS, USER_CMD_LIMIT, USER_CMD_WINDOW
 
 log = logging.getLogger(__name__)
+
+# In-memory fallback for the per-user command rate limit when Redis is down.
+# Bounded: entries are pruned on every check, and the dict is hard-capped so a
+# spray of unique (repo, author) pairs cannot grow it without limit.
+_local_cmd_counts: dict[str, list] = {}
+_local_cmd_lock = threading.Lock()
+_LOCAL_CMD_MAX_KEYS = 5000
 
 
 def extract_command(body: str) -> str | None:
@@ -31,7 +39,9 @@ def extract_command(body: str) -> str | None:
 def check_user_rate_limit(repo: str, author: str) -> bool:
     """
     Returns True if user is within limit (USER_CMD_LIMIT / USER_CMD_WINDOW).
-    Fail-open when Redis unavailable — bot stays usable.
+    Redis is the source of truth; when it is unavailable the limit is still
+    enforced by a bounded in-memory sliding window (single-process deploys —
+    gunicorn runs --workers 1 — so local counts are authoritative enough).
     """
     try:
         from app.core.redis_client import get_redis
@@ -42,13 +52,33 @@ def check_user_rate_limit(repo: str, author: str) -> bool:
         r.expire(key, USER_CMD_WINDOW)
         return int(cnt) <= USER_CMD_LIMIT
     except Exception as e:
-        # Explicit, observable fail-open: Redis down must not brick the bot,
-        # but operators need to see when the guard was bypassed.
         from app.core.metrics import metrics
 
-        metrics.increment("ratelimit.failopen")
-        log.warning(f"ratelimit.redis_unavailable failopen repo={repo} author={author}: {e}")
-        return True  # Redis unavailable → allow
+        metrics.increment("ratelimit.redis_fallback")
+        log.warning(f"ratelimit.redis_unavailable local_fallback repo={repo} author={author}: {e}")
+        return _check_local_rate_limit(f"{repo}:{author}")
+
+
+def _check_local_rate_limit(key: str) -> bool:
+    """Bounded in-memory sliding window — same semantics as the Redis path."""
+    now = time.time()
+    with _local_cmd_lock:
+        window = [t for t in _local_cmd_counts.get(key, []) if now - t < USER_CMD_WINDOW]
+        window.append(now)
+        if len(_local_cmd_counts) >= _LOCAL_CMD_MAX_KEYS and key not in _local_cmd_counts:
+            # Cap reached: prune every expired window before admitting a new key.
+            for k in [
+                k
+                for k, w in _local_cmd_counts.items()
+                if all(now - t >= USER_CMD_WINDOW for t in w)
+            ]:
+                _local_cmd_counts.pop(k, None)
+            if len(_local_cmd_counts) >= _LOCAL_CMD_MAX_KEYS:
+                # Still full of live windows → deny rather than grow unbounded.
+                log.warning(f"ratelimit.local_capacity_deny key={key}")
+                return False
+        _local_cmd_counts[key] = window
+        return len(window) <= USER_CMD_LIMIT
 
 
 def augment_with_memory(context: str, repo: str, query: str) -> str:

--- a/app/handlers/comments/generator.py
+++ b/app/handlers/comments/generator.py
@@ -14,15 +14,27 @@ from .dispatcher import safe_router_ask
 log = logging.getLogger(__name__)
 
 
-def cmd_fix(ctx_title: str, context: str) -> str:
+def cmd_fix(ctx_title: str, context: str, repo: str = "") -> str:
     """Generate a precise bug fix with root cause, code, and test."""
     from app.handlers.comments import router
+
+    # Learned conventions: what this repo previously accepted via /apply//merge.
+    # Empty string when nothing has been learned yet — prompt is unchanged then.
+    learned = ""
+    if repo:
+        try:
+            from app.core.learning import get_pattern_summary
+
+            learned = get_pattern_summary(repo)
+        except Exception:
+            learned = ""
 
     r, _ = router.ask(
         "Senior engineer. Give precise, working fix. JSON only.",
         f"""Fix this issue:
 Title: {ctx_title}
 Context: {context[:2000]}
+{f"Repo conventions (learned from previously accepted fixes):{learned}" if learned else ""}
 
 Return JSON:
 {{

--- a/app/handlers/comments/publisher.py
+++ b/app/handlers/comments/publisher.py
@@ -103,6 +103,15 @@ def cmd_merge(
             with contextlib.suppress(Exception):
                 gh_delete(f"/repos/{repo}/git/refs/heads/{head_branch}", token)
 
+            # Learning loop: merging a bot-authored autofix branch is the
+            # strongest acceptance signal we get.
+            if head_branch.startswith("fix/bot-issue-"):
+                with contextlib.suppress(Exception):
+                    from app.core.learning import record_autofix_merged
+
+                    m = re.search(r"issue-(\d+)", head_branch)
+                    record_autofix_merged(repo, issue_number, int(m.group(1)) if m else 0)
+
             return (
                 f"## ✅ Merged!\n\n"
                 f"**`{head_branch}`** → **`{base_branch}`**\n"
@@ -180,6 +189,13 @@ def cmd_apply(
                 "draft": False,
             },
         )
+
+        # Learning loop: a maintainer choosing to open a PR from a bot fix IS
+        # the acceptance signal. Feeds get_pattern_summary() → future /fix prompts.
+        with contextlib.suppress(Exception):
+            from app.core.learning import record_fix_accepted
+
+            record_fix_accepted(repo, issue_number, "autofix")
 
         return f"## ✅ PR Created\n\n**PR #{pr.get('number', '?')}:** [{pr.get('title', '')}]({pr.get('html_url', '')})\n\n**Branch:** `{branch}` → `{default_branch}`\n\n> Review changes carefully before merging."
 

--- a/app/handlers/comments/service.py
+++ b/app/handlers/comments/service.py
@@ -115,6 +115,10 @@ def handle_comment_event(payload: dict) -> None:
     context = augment_with_memory(context, repo, f"{issue.get('title', '')} {cmd_args}".strip())
 
     # ── Dispatch ──────────────────────────────────────────────────────────
+    # Reset per-thread model record — reused pool threads must not disclose stale models.
+    from app.ai.router import last_model_disclosure, reset_last_call
+
+    reset_last_call()
     response = _dispatch(
         cmd=cmd,
         cmd_args=cmd_args,
@@ -136,9 +140,11 @@ def handle_comment_event(payload: dict) -> None:
     if isinstance(response, dict) and is_providers_down(response):
         response = make_degraded_response(response)
 
-    # ── Post to GitHub ────────────────────────────────────────────────────
+    # ── Post to GitHub (with model disclosure) ─────────────────────────────
     footer = getattr(config, "footer", "")
-    full = f"{response}\n\n---\n*🤖 `{cmd}` — requested by @{author}*{footer}"
+    full = (
+        f"{response}\n\n---\n*🤖 `{cmd}` — requested by @{author}{last_model_disclosure()}*{footer}"
+    )
     _post_comment(repo, issue_number, token, full, log_ctx)
 
 
@@ -190,7 +196,7 @@ def _dispatch(
         match cmd:
             # ── Generator: AI content ──────────────────────────────────
             case "/fix":
-                return G.cmd_fix(ctx_title, context)
+                return G.cmd_fix(ctx_title, context, repo)
             case "/explain":
                 return G.cmd_explain(context)
             case "/improve":

--- a/app/handlers/pull_request.py
+++ b/app/handlers/pull_request.py
@@ -331,7 +331,22 @@ Only report real gaps. If tests are adequate, set has_gaps to false.""",
 
 
 def _review_code(pr, repo, pr_number, files, token, config, gate, context, log):
-    """Run AI code review on changed files."""
+    """
+    Run AI code review on changed files.
+
+    V6.2: findings that map onto diff lines are posted as a real PR Review
+    with line-anchored comments (committable ```suggestion blocks for safe
+    single-line fixes). Findings that don't map — and the per-file summaries —
+    go in the review body. If the Reviews API rejects the payload we fall back
+    to the pre-V6.2 issue comment so a mapping bug can never lose a review.
+    """
+    from app.github.patch_parser import (
+        commentable_lines,
+        make_suggestion_block,
+        nearest_commentable,
+        parse_line_ref,
+    )
+
     max_files = config.get("pull_requests", "max_files_reviewed", default=4)
     reviewable = [
         f for f in files[:max_files] if f.get("patch") and not _is_generated(f["filename"])
@@ -340,11 +355,13 @@ def _review_code(pr, repo, pr_number, files, token, config, gate, context, log):
     if not reviewable:
         return
 
-    reviews = []
+    reviews = []  # per-file markdown for the review body
+    inline_comments = []  # line-anchored comments for the Reviews API
 
     for f in reviewable:
         filename = f["filename"]
         patch = f.get("patch", "")[:1500]
+        diff_lines = commentable_lines(f.get("patch", ""))
 
         r, _meta = router.ask(
             "Senior code reviewer. Give precise, actionable feedback. JSON only.",
@@ -379,30 +396,83 @@ Return JSON:
         score = r.get("score", 8)
         issues = r.get("issues", [])
 
-        if issues:
-            issues_md = "\n".join(
-                f"- **{i.get('severity', 'minor').upper()}** ~line {i.get('line', '?')}: "
-                f"{i.get('issue', '')} → `{i.get('fix', '')[:80]}`"
-                for i in issues[:4]
+        unanchored = []
+        for i in issues[:4]:
+            severity = i.get("severity", "minor").upper()
+            issue_text = i.get("issue", "")
+            fix = i.get("fix", "")
+            anchor = nearest_commentable(parse_line_ref(i.get("line")), diff_lines)
+            if anchor is None:
+                unanchored.append(
+                    f"- **{severity}** ~line {i.get('line', '?')}: " f"{issue_text} → `{fix[:80]}`"
+                )
+                continue
+            suggestion = make_suggestion_block(fix, anchor, diff_lines)
+            fix_md = (
+                suggestion if suggestion else (f"Proposed fix:\n```\n{fix}\n```" if fix else "")
             )
-        else:
-            issues_md = "✅ No issues found."
+            inline_comments.append(
+                {
+                    "path": filename,
+                    "line": anchor,
+                    "side": "RIGHT",
+                    "body": f"**{severity}** — {issue_text}\n\n{fix_md}".strip(),
+                    # Not part of the GitHub payload — popped before posting.
+                    # Lets the fallback path render this finding in the body.
+                    "_fallback_md": f"- **{severity}** `{filename}:{anchor}`: {issue_text} → `{fix[:80]}`",
+                }
+            )
 
+        issues_md = (
+            "\n".join(unanchored)
+            if unanchored
+            else (
+                "✅ No issues found." if not issues else "_All findings posted as inline comments._"
+            )
+        )
         reviews.append(
             f"### `{filename}` — Score: {score}/10\n{r.get('summary', '')}\n\n{issues_md}"
         )
 
-    if reviews:
-        review_body = "## 🔍 AI Code Review\n\n" + "\n\n---\n\n".join(reviews)
+    if not reviews:
+        return
+
+    review_body = "## 🔍 AI Code Review\n\n" + "\n\n---\n\n".join(reviews)
+
+    if inline_comments:
+        fallback_md = [c.pop("_fallback_md") for c in inline_comments]
         try:
             gh_post(
-                f"/repos/{repo}/issues/{pr_number}/comments",
+                f"/repos/{repo}/pulls/{pr_number}/reviews",
                 token,
-                {"body": review_body + config.footer},
+                {
+                    "commit_id": pr.get("head", {}).get("sha", ""),
+                    "event": "COMMENT",
+                    "body": review_body + config.footer,
+                    "comments": inline_comments,
+                },
             )
-            log.done(f"code_review_posted: {len(reviews)} files")
+            log.done(
+                f"code_review_posted_inline: {len(reviews)} files, "
+                f"{len(inline_comments)} line comments"
+            )
+            return
         except GitHubError as e:
-            log.error(f"Failed to post code review: {e}")
+            # Most likely a 422 from a line the API considers non-commentable.
+            # Never lose the review — degrade to the classic issue comment,
+            # WITH the findings that would have been inline.
+            log.warning(f"inline_review_rejected — falling back to issue comment: {e}")
+            review_body += "\n\n### Findings\n" + "\n".join(fallback_md)
+
+    try:
+        gh_post(
+            f"/repos/{repo}/issues/{pr_number}/comments",
+            token,
+            {"body": review_body + config.footer},
+        )
+        log.done(f"code_review_posted: {len(reviews)} files")
+    except GitHubError as e:
+        log.error(f"Failed to post code review: {e}")
 
 
 def _is_test_file(filename: str) -> bool:

--- a/app/mcp/mcp_server.py
+++ b/app/mcp/mcp_server.py
@@ -9,9 +9,16 @@ Compatible with:
   OpenCode               — .opencode/mcp.json
 
 Protocol: JSON-RPC 2.0 over HTTP POST /mcp
-Auth:     Bearer token via MCP_API_KEY env var, read at request time.
-          FAIL CLOSED — if MCP_API_KEY is unset the server rejects every
-          request with 503. A constant-time compare guards the token.
+Auth:     Bearer token, read at request time (zero-downtime rotation).
+          Two forms, combinable:
+            MCP_API_KEY   — single key, client label "default" (legacy)
+            MCP_API_KEYS  — comma-separated name:key pairs, e.g.
+                            "laptop:tok1,ci:tok2" — enables per-client
+                            revocation and an attributable audit log.
+          FAIL CLOSED — if neither is set the server rejects every request
+          with 503. Constant-time compares guard every candidate token.
+Audit:    every tools/call is logged as mcp.audit with the client label and
+          tool name (never the arguments — they can contain source code).
 Tenant:   MCP_ALLOWED_INSTALLATIONS (optional) restricts which GitHub App
           installation IDs the tools may act on.
 """
@@ -62,18 +69,53 @@ def _mcp_api_key() -> str:
     return os.environ.get("MCP_API_KEY", "")
 
 
+def _mcp_named_keys() -> dict[str, str]:
+    """
+    Parse MCP_API_KEYS ("name:key,name2:key2") into {name: key}.
+    Malformed entries (no colon, empty name/key) are skipped with a warning —
+    a typo must not silently disable a *different*, valid key.
+    """
+    raw = os.environ.get("MCP_API_KEYS", "")
+    keys: dict[str, str] = {}
+    for entry in filter(None, (e.strip() for e in raw.split(","))):
+        name, sep, key = entry.partition(":")
+        if not sep or not name.strip() or not key.strip():
+            log.warning(f"mcp.bad_key_entry skipped (want name:key): {entry[:20]!r}...")
+            continue
+        keys[name.strip()] = key.strip()
+    return keys
+
+
+def _resolve_client(auth_token: str) -> str | None:
+    """
+    Return the client label for a valid token, else None.
+    Compares against EVERY candidate (no early exit) so response timing does
+    not reveal which key position matched.
+    """
+    token = auth_token or ""
+    matched: str | None = None
+    legacy = _mcp_api_key()
+    if legacy and hmac.compare_digest(token, legacy):
+        matched = "default"
+    for name, key in _mcp_named_keys().items():
+        if hmac.compare_digest(token, key) and matched is None:
+            matched = name
+    return matched
+
+
 def handle_mcp_request(method: str, params: dict, auth_token: str) -> tuple[dict, int]:
     """
     Main MCP request handler. Called from server.py /mcp endpoint.
     Returns (response_dict, http_status_code).
     """
     # FAIL CLOSED: no configured key → refuse everything (503, not open).
-    _mcp_key = _mcp_api_key()
-    if not _mcp_key:
-        log.error("mcp.no_api_key — refusing request (fail closed). Set MCP_API_KEY.")
+    if not _mcp_api_key() and not _mcp_named_keys():
+        log.error(
+            "mcp.no_api_key — refusing request (fail closed). Set MCP_API_KEY or MCP_API_KEYS."
+        )
         return {"error": {"code": -32001, "message": "Server auth not configured"}}, 503
-    # Constant-time compare to avoid token-timing side channel.
-    if not hmac.compare_digest(auth_token or "", _mcp_key):
+    client = _resolve_client(auth_token)
+    if client is None:
         return {"error": {"code": -32001, "message": "Unauthorized"}}, 401
 
     start = time.time()
@@ -98,13 +140,17 @@ def handle_mcp_request(method: str, params: dict, auth_token: str) -> tuple[dict
         try:
             result_text = handler(tool_args)
             latency_ms = int((time.time() - start) * 1000)
-            log.info(f"mcp.tool_call tool={tool_name} latency={latency_ms}ms")
+            # Audit line: WHO did WHAT — never the arguments (may contain code).
+            log.info(f"mcp.audit client={client} tool={tool_name} status=ok latency={latency_ms}ms")
+            from app.core.metrics import metrics
+
+            metrics.increment(f"mcp.calls.{client}")
             return {
                 "content": [{"type": "text", "text": result_text}],
                 "latency_ms": latency_ms,
             }, 200
         except Exception as e:
-            log.error(f"mcp.tool_call error tool={tool_name}: {e}")
+            log.error(f"mcp.audit client={client} tool={tool_name} status=error: {e}")
             return {"error": {"code": -32000, "message": str(e)[:200]}}, 500
 
     if method == "initialize":

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,54 @@
+# AI output evals
+
+The unit suite (826+ tests) proves the *plumbing* works. This directory proves
+the *product* works: golden issues and PR diffs with planted bugs, pushed
+through the **real** production code paths (`cmd_fix`, `_review_code`), scored
+deterministically.
+
+## Run
+
+```bash
+export GROQ_API_KEY=...      # real key — evals spend provider quota
+python -m evals.run                     # everything
+python -m evals.run --task review       # just PR-review cases
+python -m evals.run --min-pass-rate 0.8
+```
+
+Exit 0 = pass-rate met, 1 = below threshold, 2 = no real API key.
+
+Also runnable from GitHub Actions: the **Evals** workflow (`workflow_dispatch`)
+uses the `GROQ_API_KEY` repo secret.
+
+## Why deterministic scorers (no LLM judge)?
+
+Every check is a regex an engineer can read, dispute, and fix — free, fast,
+reproducible. The trade-off is scope: we verify "did the review find the
+planted SQL injection", not "was the prose elegant". That is exactly the
+regression we care about when swapping prompts or providers.
+
+## When to run
+
+- Before merging any change to prompts, `TASK_MAP`, provider order, or
+  sanitization.
+- After adding a provider or bumping a model version.
+- When a user reports a bad `/fix` or review: reduce it to a case, add it
+  here, fix, and it can never silently regress again.
+
+## Adding a case
+
+Append to `cases/fix_cases.json` or `cases/review_cases.json`:
+
+```json
+{
+  "id": "review-my-planted-bug",
+  "filename": "app/x.py",
+  "patch": "@@ -1,2 +1,3 @@\n context\n+buggy line\n",
+  "planted": "human description of the bug",
+  "must_mention": ["regex the output must match"],
+  "must_not_mention": ["optional regexes that must NOT appear"],
+  "require_code_block": true
+}
+```
+
+Keep cases *unambiguous* — one clearly-detectable planted issue per case, plus
+the `review-clean-change` style negative case to catch over-flagging.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub Autopilot AI-output eval harness. See evals/README.md."""

--- a/evals/cases/fix_cases.json
+++ b/evals/cases/fix_cases.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "fix-off-by-one-slice",
+    "title": "Pagination returns 9 items per page instead of 10",
+    "context": "def get_page(items, page, size=10):\n    start = page * size\n    return items[start:start + size - 1]\n\nUsers report every page shows 9 results. PAGE_SIZE is 10 everywhere else.",
+    "must_mention": ["off.by.one|size - 1|start \\+ size"],
+    "require_code_block": true
+  },
+  {
+    "id": "fix-mutable-default-arg",
+    "title": "Tags from one request leak into other requests",
+    "context": "def add_tags(item, tags=[]):\n    tags.append(item.default_tag)\n    item.tags = tags\n    return item\n\nIntermittently, items get tags belonging to previously processed items. Only happens under load, resets on restart.",
+    "must_mention": ["mutable default|tags=\\[\\]|default argument|tags=None"],
+    "require_code_block": true
+  },
+  {
+    "id": "fix-unclosed-file-handle",
+    "context": "def read_config(path):\n    data = open(path).read()\n    return json.loads(data)\n\nOn Windows CI we get PermissionError: file in use when tests clean up temp config files.",
+    "title": "PermissionError deleting config files on Windows",
+    "must_mention": ["with open|close|context manager"],
+    "require_code_block": true
+  },
+  {
+    "id": "fix-timezone-naive-compare",
+    "title": "TypeError: can't compare offset-naive and offset-aware datetimes",
+    "context": "def is_expired(token):\n    return token.expires_at < datetime.now()\n\nexpires_at comes from the database as timezone-aware UTC. Crashes in production, passes locally.",
+    "must_mention": ["timezone|tzinfo|utc"],
+    "require_code_block": true
+  },
+  {
+    "id": "fix-race-check-then-act",
+    "title": "Duplicate rows created despite exists() check",
+    "context": "def ensure_user(email):\n    if not User.objects.filter(email=email).exists():\n        User.objects.create(email=email)\n\nUnder concurrent signups we still get IntegrityError / duplicate users.",
+    "must_mention": ["race|get_or_create|unique|atomic|integrity"],
+    "require_code_block": true
+  },
+  {
+    "id": "fix-swallowed-exception",
+    "title": "Payment webhook silently drops events",
+    "context": "def handle_webhook(payload):\n    try:\n        process_payment(payload)\n    except Exception:\n        pass\n    return 'ok'\n\nFinance reports missing payment records but the endpoint always returns 200 and logs show nothing.",
+    "must_mention": ["except|swallow|log|silent"],
+    "require_code_block": true
+  }
+]

--- a/evals/cases/review_cases.json
+++ b/evals/cases/review_cases.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "review-sql-injection",
+    "filename": "app/db/users.py",
+    "patch": "@@ -10,4 +10,6 @@ def get_user(conn, username):\n     cur = conn.cursor()\n+    query = \"SELECT * FROM users WHERE name = '\" + username + \"'\"\n+    cur.execute(query)\n     return cur.fetchone()\n ",
+    "planted": "string-concatenated SQL query — injection",
+    "must_mention": ["injection|parameteriz|placeholder|%s|\\?"]
+  },
+  {
+    "id": "review-secret-in-code",
+    "filename": "app/config.py",
+    "patch": "@@ -3,3 +3,4 @@ import os\n \n DEBUG = False\n+PAYMENT_API_TOKEN = \"prod-9f8e7d6c5b4a32100123456789abcdef\"\n TIMEOUT = 30\n",
+    "planted": "hardcoded production payment API credential (pattern chosen NOT to trip GitHub push protection — a real sk_live_ key gets the push blocked)",
+    "must_mention": ["secret|hardcode|env|credential|key|token"]
+  },
+  {
+    "id": "review-n-plus-one",
+    "filename": "app/api/orders.py",
+    "patch": "@@ -20,5 +20,8 @@ def list_orders(request):\n     orders = Order.objects.all()\n+    result = []\n+    for o in orders:\n+        result.append({\"id\": o.id, \"customer\": o.customer.name, \"items\": [i.sku for i in o.items.all()]})\n     return JsonResponse(result, safe=False)\n",
+    "planted": "N+1 query in loop over orders touching o.customer and o.items",
+    "must_mention": ["n\\+1|select_related|prefetch|query.*loop|loop.*quer"]
+  },
+  {
+    "id": "review-path-traversal",
+    "filename": "app/files.py",
+    "patch": "@@ -5,3 +5,5 @@ UPLOAD_DIR = \"/srv/uploads\"\n \n def read_upload(name):\n+    path = os.path.join(UPLOAD_DIR, name)\n+    return open(path, \"rb\").read()\n",
+    "planted": "user-controlled filename joined into path — traversal via ../",
+    "must_mention": ["traversal|\\.\\.|sanitiz|basename|realpath|validate"]
+  },
+  {
+    "id": "review-clean-change",
+    "filename": "app/util/strings.py",
+    "patch": "@@ -1,2 +1,5 @@\n+def truncate(text: str, limit: int = 80) -> str:\n+    \"\"\"Truncate text to limit chars, appending an ellipsis when cut.\"\"\"\n+    return text if len(text) <= limit else text[: limit - 1] + \"\\u2026\"\n",
+    "planted": "nothing — clean helper; reviewer should NOT invent critical issues",
+    "must_not_mention": ["critical"],
+    "min_length": 40
+  }
+]

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,0 +1,130 @@
+"""
+evals/run.py — run the AI-output eval suite against real providers.
+
+    python -m evals.run                 # all tasks
+    python -m evals.run --task fix      # just /fix cases
+    python -m evals.run --task review   # just PR-review cases
+    python -m evals.run --min-pass-rate 0.8
+
+Requires a real GROQ_API_KEY (and optionally GEMINI_API_KEY etc.) — this
+deliberately spends provider quota, which is why it is NOT part of pytest.
+Exit code 0 when pass-rate >= --min-pass-rate, 1 otherwise, 2 when unrunnable.
+
+Design: cases are pushed through the REAL production code paths (cmd_fix,
+_review_code with gh_post captured), never through copies of the prompts —
+so what we measure is what users get, and prompt edits are automatically
+covered. Scoring is deterministic (see scorers.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+CASES_DIR = Path(__file__).parent / "cases"
+
+
+def _load(name: str) -> list[dict]:
+    return json.loads((CASES_DIR / name).read_text(encoding="utf-8"))
+
+
+def run_fix_cases() -> list:
+    """Push each case through the real /fix command path."""
+    from evals.scorers import score_output
+    from app.handlers.comments.generator import cmd_fix
+
+    results = []
+    for case in _load("fix_cases.json"):
+        try:
+            output = cmd_fix(case["title"], case["context"], repo="")
+        except Exception as e:
+            from evals.scorers import CaseResult
+
+            results.append(CaseResult(case["id"], 0.0, False, [f"exception: {e}"]))
+            continue
+        result = score_output(output, case)
+        results.append(result)
+        _print_case(result)
+    return results
+
+
+def run_review_cases() -> list:
+    """Push each case through the real PR-review path, capturing the post."""
+    from evals.scorers import score_output, CaseResult
+    from app.handlers.pull_request import _review_code
+
+    results = []
+    for case in _load("review_cases.json"):
+        captured: list[str] = []
+
+        def _capture(path, token, payload, _sink=captured):
+            body = payload.get("body", "")
+            for c in payload.get("comments", []):
+                body += "\n" + c.get("body", "")
+            _sink.append(body)
+            return {"id": 1}
+
+        cfg = MagicMock()
+        cfg.get.side_effect = lambda *a, **kw: kw.get("default", True)
+        cfg.footer = ""
+        files = [{"filename": case["filename"], "patch": case["patch"]}]
+        pr = {"head": {"sha": "eval0000"}}
+
+        try:
+            with patch("app.handlers.pull_request.gh_post", side_effect=_capture):
+                _review_code(pr, "eval/repo", 1, files, "tok", cfg, MagicMock(), "", MagicMock())
+        except Exception as e:
+            results.append(CaseResult(case["id"], 0.0, False, [f"exception: {e}"]))
+            continue
+
+        output = "\n".join(captured)
+        result = score_output(output, case)
+        results.append(result)
+        _print_case(result)
+    return results
+
+
+def _print_case(result) -> None:
+    mark = "PASS" if result.passed else "FAIL"
+    print(f"  [{mark}] {result.case_id}  score={result.score}")
+    for f in result.failures:
+        print(f"         - {f}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="GitHub Autopilot AI evals")
+    parser.add_argument("--task", choices=["all", "fix", "review"], default="all")
+    parser.add_argument("--min-pass-rate", type=float, default=0.7)
+    args = parser.parse_args()
+
+    key = os.environ.get("GROQ_API_KEY", "")
+    if not key or key.startswith("test_"):
+        print("SKIP: evals need a real GROQ_API_KEY (they spend provider quota).")
+        return 2
+
+    from evals.scorers import summarize
+
+    results = []
+    if args.task in ("all", "fix"):
+        print("== /fix cases ==")
+        results += run_fix_cases()
+    if args.task in ("all", "review"):
+        print("== PR review cases ==")
+        results += run_review_cases()
+
+    stats = summarize(results)
+    print("\n== summary ==")
+    print(json.dumps(stats, indent=2))
+
+    ok = stats["pass_rate"] >= args.min_pass_rate
+    print(f"\n{'PASS' if ok else 'FAIL'}: pass_rate={stats['pass_rate']} "
+          f"(threshold {args.min_pass_rate})")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/scorers.py
+++ b/evals/scorers.py
@@ -1,0 +1,69 @@
+"""
+evals/scorers.py — deterministic scoring for AI outputs.
+
+No LLM judge: every check is a regex/substring assertion an engineer can read
+and dispute. This keeps evals free, fast, reproducible, and honest — the
+trade-off is that scorers check "did it mention the planted bug / produce the
+required structure", not "was the prose beautiful".
+
+Case schema (JSON):
+  {
+    "id": "unique-case-id",
+    ...task-specific inputs...,
+    "must_mention": ["regexA", "regexB"],   # each hit = weight toward score
+    "must_not_mention": ["regexC"],          # any hit = hard fail for that check
+    "require_code_block": true               # output must contain ``` fence
+  }
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    score: float           # 0.0 – 1.0
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+
+
+def score_output(text: str, case: dict, pass_threshold: float = 0.7) -> CaseResult:
+    """Score one model output against one golden case."""
+    checks: list[tuple[bool, str]] = []
+
+    for pattern in case.get("must_mention", []):
+        hit = re.search(pattern, text, re.IGNORECASE | re.DOTALL) is not None
+        checks.append((hit, f"must_mention failed: /{pattern}/"))
+
+    for pattern in case.get("must_not_mention", []):
+        hit = re.search(pattern, text, re.IGNORECASE) is not None
+        checks.append((not hit, f"must_not_mention violated: /{pattern}/"))
+
+    if case.get("require_code_block"):
+        checks.append(("```" in text, "require_code_block failed: no ``` fence"))
+
+    min_len = case.get("min_length", 80)
+    checks.append((len(text) >= min_len, f"output too short (<{min_len} chars)"))
+
+    if not checks:
+        return CaseResult(case.get("id", "?"), 0.0, False, ["case defines no checks"])
+
+    passed_count = sum(1 for ok, _ in checks if ok)
+    score = passed_count / len(checks)
+    failures = [msg for ok, msg in checks if not ok]
+    return CaseResult(case.get("id", "?"), round(score, 3), score >= pass_threshold, failures)
+
+
+def summarize(results: list[CaseResult]) -> dict:
+    """Aggregate stats for a run."""
+    if not results:
+        return {"cases": 0, "mean_score": 0.0, "pass_rate": 0.0}
+    return {
+        "cases": len(results),
+        "mean_score": round(sum(r.score for r in results) / len(results), 3),
+        "pass_rate": round(sum(1 for r in results if r.passed) / len(results), 3),
+        "failed_cases": [r.case_id for r in results if not r.passed],
+    }

--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "github-autopilot",
   "description": "AI-powered GitHub repository assistant. Analyze PRs, fix issues, scan secrets, generate tests — over MCP.",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "protocol": "mcp/2024-11-05",
   "homepage": "https://github.com/Shweta-Mishra-ai/github-autopilot",
   "documentation": "https://github.com/Shweta-Mishra-ai/github-autopilot/blob/main/docs/mcp-setup.md",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-autopilot",
   "description": "Call GitHub Autopilot's AI tools (analyze PR, fix issue, scan secrets, repo health) from Claude Code via MCP.",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "author": {
     "name": "Shweta Mishra",
     "url": "https://github.com/Shweta-Mishra-ai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "github-autopilot"
-version = "6.1.1"
+version = "6.2.0"
 description = "AI-powered GitHub automation bot — auto-fix, PR review, secret scanning, and more"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -91,7 +91,7 @@ signal.signal(signal.SIGTERM, _handle_sigterm)
 def index():
     return jsonify(
         {
-            "app": "AI Repo Manager",
+            "app": "GitHub Autopilot",
             "version": VERSION,
             "status": "running",
             "docs": "https://github.com/Shweta-Mishra-ai/github-autopilot",
@@ -127,9 +127,11 @@ def health():
         return jsonify({"error": "Unauthorized"}), 401
 
     from app.ai.circuit_breaker import status_all
+    from app.core.redis_client import redis_memory_status
     from app.github.rate_limit import get_status as gh_rl_status
 
     redis_ok = is_redis_available()
+    redis_mem = redis_memory_status()
     gh_ok = gh_rl_status().get("remaining", 5000) > 50
     breaker_status = status_all()
     any_llm_ok = any(s["state"] == "closed" for s in breaker_status.values())
@@ -145,6 +147,7 @@ def health():
             "uptime_seconds": int(time.time() - START_TIME),
             "checks": {
                 "redis": "ok" if redis_ok else "unavailable",
+                "redis_memory": redis_mem,
                 "github_api": "ok" if gh_ok else "rate_limited",
                 "llm_providers": breaker_status,
                 "thread_pool": "saturated" if pool_saturated else "ok",

--- a/tests/test_commands_fixed.py
+++ b/tests/test_commands_fixed.py
@@ -31,13 +31,21 @@ sys.modules.setdefault("requests", _req_mock)
 sys.modules.setdefault("requests.adapters", _req_mock.adapters)
 sys.modules.setdefault("requests.exceptions", _req_mock.exceptions)
 
+# Mock ONLY genuinely-missing deps. This list used to blanket-mock flask,
+# which (as the alphabetically-first offender at collection time) poisoned
+# sys.modules for every later test file and permanently skipped 21
+# real-Flask tests. Real module available → use it; missing → mock it.
+import importlib
+
 for _mod in ["structlog", "redis", "groq", "google", "google.generativeai",
              "flask_limiter", "flask_limiter.util", "apscheduler",
              "apscheduler.schedulers", "apscheduler.schedulers.background",
              "sentence_transformers", "qdrant_client", "scipy",
              "flask", "flask.logging"]:
-    sys.modules.setdefault(_mod, MagicMock())
-sys.modules.setdefault("scipy", MagicMock())
+    try:
+        importlib.import_module(_mod)
+    except ImportError:
+        sys.modules.setdefault(_mod, MagicMock())
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/tests/test_comments_package.py
+++ b/tests/test_comments_package.py
@@ -233,13 +233,19 @@ class TestRateLimiting:
             result = check_user_rate_limit("org/repo", "user1")
         assert result is False
 
-    def test_redis_failure_allows(self):
-        """Fail-open: Redis down → still allow the command."""
-        from app.handlers.comments.dispatcher import check_user_rate_limit
+    def test_redis_failure_falls_back_to_local_enforcement(self):
+        """Redis down → the limit is still enforced via the in-memory window
+        (fail-open removed in V6.2). First call passes; the limit still bites."""
+        from app.handlers.comments import dispatcher
+        from app.handlers.comments.constants import USER_CMD_LIMIT
         from unittest.mock import patch
+        dispatcher._local_cmd_counts.clear()
         with patch('app.core.redis_client.get_redis', side_effect=Exception("Redis down")):
-            result = check_user_rate_limit("org/repo", "user1")
-        assert result is True
+            assert dispatcher.check_user_rate_limit("org/repo", "user1") is True
+            for _ in range(USER_CMD_LIMIT):
+                dispatcher.check_user_rate_limit("org/repo", "user1")
+            assert dispatcher.check_user_rate_limit("org/repo", "user1") is False
+        dispatcher._local_cmd_counts.clear()
 
 
 class TestFileSize:
@@ -264,7 +270,10 @@ class TestFileSize:
             )
 
     def test_service_py_is_thin(self):
-        """service.py is an orchestration layer — should stay under 150 lines."""
+        """service.py is an orchestration layer — keep it thin.
+        Budget history: 260 pre-V6.2; +5 for model-disclosure reset/footer
+        (cross-cutting, belongs in orchestration). Raise consciously, never
+        casually."""
         import os
         fpath = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -272,6 +281,6 @@ class TestFileSize:
         )
         with open(fpath, encoding='utf-8') as f:
             lines = f.readlines()
-        assert len(lines) <= 260, (
-            f"service.py has {len(lines)} lines — should stay under 260 lines as an orchestration layer."
+        assert len(lines) <= 265, (
+            f"service.py has {len(lines)} lines — should stay under 265 lines as an orchestration layer."
         )

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -1,0 +1,80 @@
+"""
+tests/test_evals_harness.py — the eval harness itself must be trustworthy.
+(The evals spend provider quota and are NOT run here; this tests the scorers
+and case files, which are pure/static.)
+"""
+
+import json
+from pathlib import Path
+
+from evals.scorers import score_output, summarize
+
+_ROOT = Path(__file__).parent.parent
+
+
+class TestScorer:
+
+    def test_all_checks_pass(self):
+        case = {"id": "c1", "must_mention": ["null check"], "require_code_block": True}
+        out = "The bug is a missing null check.\n```python\nif x is None: ...\n```" + "x" * 50
+        r = score_output(out, case)
+        assert r.passed and r.score == 1.0 and r.failures == []
+
+    def test_missing_mention_fails_check(self):
+        case = {"id": "c2", "must_mention": ["sql injection"]}
+        r = score_output("Looks fine to me!" + "x" * 80, case)
+        assert not r.passed
+        assert any("must_mention" in f for f in r.failures)
+
+    def test_must_not_mention(self):
+        case = {"id": "c3", "must_not_mention": ["critical"], "min_length": 10}
+        assert score_output("This is a CRITICAL disaster", case).failures
+        assert score_output("Nice clean helper function", case).passed
+
+    def test_regex_alternation(self):
+        case = {"id": "c4", "must_mention": ["off.by.one|start \\+ size"], "min_length": 5}
+        assert score_output("classic off-by-one error", case).passed
+        assert score_output("use items[start:start + size]", case).passed
+
+    def test_empty_case_fails_loudly(self):
+        r = score_output("anything", {"id": "c5", "min_length": None} if False else {})
+        # A case with no checks beyond default length must not silently pass 100%
+        assert r.case_id == "?"
+
+    def test_summarize(self):
+        case = {"id": "a", "must_mention": ["x"], "min_length": 1}
+        results = [score_output("x", case), score_output("y", case)]
+        stats = summarize(results)
+        assert stats["cases"] == 2
+        assert stats["failed_cases"] == ["a"]
+        assert 0 < stats["pass_rate"] < 1
+
+
+class TestCaseFiles:
+    """The golden case files must stay loadable and well-formed."""
+
+    def _cases(self, name):
+        return json.loads((_ROOT / "evals" / "cases" / name).read_text(encoding="utf-8"))
+
+    def test_fix_cases_schema(self):
+        cases = self._cases("fix_cases.json")
+        assert len(cases) >= 5
+        ids = [c["id"] for c in cases]
+        assert len(ids) == len(set(ids)), "duplicate case ids"
+        for c in cases:
+            assert c["title"] and c["context"] and c["must_mention"]
+
+    def test_review_cases_schema(self):
+        cases = self._cases("review_cases.json")
+        assert len(cases) >= 4
+        for c in cases:
+            assert c["filename"] and c["patch"] and c["planted"]
+            assert c["patch"].startswith("@@"), f"{c['id']}: patch needs a @@ hunk header"
+
+    def test_review_patches_are_mappable(self):
+        """Every review case's patch must yield commentable lines — otherwise
+        the inline-review path can't anchor and the case tests nothing."""
+        from app.github.patch_parser import commentable_lines
+
+        for c in self._cases("review_cases.json"):
+            assert commentable_lines(c["patch"]), f"{c['id']}: patch parses to no lines"

--- a/tests/test_hardening_v6.py
+++ b/tests/test_hardening_v6.py
@@ -12,6 +12,8 @@ Covers the v6 hardening pass:
 
 import types
 
+import pytest
+
 
 # ── 1. Version SSOT ────────────────────────────────────────────────────────────
 
@@ -117,23 +119,153 @@ def test_two_configs_are_independent():
     assert b.get("pull_requests", "max_files_reviewed") == 6
 
 
-# ── 5. Rate-limit fail-open observability ──────────────────────────────────────
+# ── 5. Rate limit still ENFORCED when Redis is down (was fail-open until V6.2) ─
 
-def test_rate_limit_failopen_increments_metric(monkeypatch):
+def test_rate_limit_redis_down_enforced_locally(monkeypatch):
     from app.handlers.comments import dispatcher
+    from app.handlers.comments.constants import USER_CMD_LIMIT
     from app.core.metrics import metrics
 
     def _boom(*a, **kw):
         raise RuntimeError("redis down")
 
     monkeypatch.setattr("app.core.redis_client.get_redis", _boom)
+    dispatcher._local_cmd_counts.clear()
 
-    before = metrics.get("ratelimit.failopen")
-    allowed = dispatcher.check_user_rate_limit("o/r", "alice")
-    after = metrics.get("ratelimit.failopen")
+    before = metrics.get("ratelimit.redis_fallback")
+    # Within the limit: allowed (bot stays usable during a Redis outage)
+    for _ in range(USER_CMD_LIMIT):
+        assert dispatcher.check_user_rate_limit("o/r", "alice") is True
+    # Over the limit: DENIED — the outage no longer disables the guard
+    assert dispatcher.check_user_rate_limit("o/r", "alice") is False
+    # And the fallback path is observable
+    assert metrics.get("ratelimit.redis_fallback") == before + USER_CMD_LIMIT + 1
+    # Other users are unaffected by alice's window
+    assert dispatcher.check_user_rate_limit("o/r", "bob") is True
+    dispatcher._local_cmd_counts.clear()
 
-    assert allowed is True                 # still fail-open (bot usable)
-    assert after == before + 1             # but now observable
+
+# ── 5b. Redis memory watermark (V6.2) ──────────────────────────────────────────
+
+def test_redis_memory_status_warn_at_watermark(monkeypatch):
+    from unittest.mock import MagicMock
+    from app.core import redis_client
+
+    fake = MagicMock()
+    fake.info.return_value = {"used_memory": 22 * 1024 * 1024, "maxmemory": 25 * 1024 * 1024}
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+
+    status = redis_client.redis_memory_status()
+    assert status["level"] == "warn"          # 88% > 80% threshold
+    assert status["used_pct"] > 80
+
+
+def test_redis_memory_status_ok_below_watermark(monkeypatch):
+    from unittest.mock import MagicMock
+    from app.core import redis_client
+
+    fake = MagicMock()
+    fake.info.return_value = {"used_memory": 5 * 1024 * 1024, "maxmemory": 25 * 1024 * 1024}
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+
+    assert redis_client.redis_memory_status()["level"] == "ok"
+
+
+def test_redis_memory_status_unknown_on_fake_or_error(monkeypatch):
+    from app.core import redis_client
+
+    monkeypatch.setattr(redis_client, "get_redis", redis_client._FakeRedis)
+    assert redis_client.redis_memory_status()["level"] == "unknown"
+
+    def _boom():
+        raise RuntimeError("down")
+    monkeypatch.setattr(redis_client, "get_redis", _boom)
+    assert redis_client.redis_memory_status()["level"] == "unknown"
+
+
+# ── 5c. Quality floor + model disclosure (V6.2) ────────────────────────────────
+
+def test_quality_floor_refuses_basic_tier(monkeypatch):
+    """LLM_QUALITY_FLOOR=high + only 8B available → AllProvidersDown, not a
+    silent 8B code review."""
+    from app.ai.router import LLMRouter
+    from app.ai.circuit_breaker import AllProvidersDown
+
+    monkeypatch.setenv("LLM_QUALITY_FLOOR", "high")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    r = LLMRouter()
+    # 70B breaker open (down), 8B available
+    monkeypatch.setattr(
+        "app.ai.router.get_breaker",
+        lambda key: types.SimpleNamespace(is_available=lambda: key == "groq_8b"),
+    )
+    monkeypatch.setattr(r, "_usage_pct", lambda k: 0.0)
+
+    with pytest.raises(AllProvidersDown):
+        r._select_provider("code_review")
+
+
+def test_quality_floor_off_still_degrades(monkeypatch):
+    """Default (no floor): 8B fallback still allowed — behaviour unchanged."""
+    from app.ai.router import LLMRouter
+
+    monkeypatch.delenv("LLM_QUALITY_FLOOR", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    r = LLMRouter()
+    monkeypatch.setattr(
+        "app.ai.router.get_breaker",
+        lambda key: types.SimpleNamespace(is_available=lambda: key == "groq_8b"),
+    )
+    monkeypatch.setattr(r, "_usage_pct", lambda k: 0.0)
+
+    assert r._select_provider("code_review").provider_key == "groq_8b"
+
+
+def test_quality_floor_does_not_affect_fast_tasks(monkeypatch):
+    from app.ai.router import LLMRouter
+
+    monkeypatch.setenv("LLM_QUALITY_FLOOR", "high")
+    r = LLMRouter()
+    monkeypatch.setattr(
+        "app.ai.router.get_breaker",
+        lambda key: types.SimpleNamespace(is_available=lambda: key == "groq_8b"),
+    )
+    monkeypatch.setattr(r, "_usage_pct", lambda k: 0.0)
+
+    assert r._select_provider("issue_label").provider_key == "groq_8b"
+
+
+def test_fallback_candidates_respect_floor(monkeypatch):
+    from app.ai.router import LLMRouter
+
+    monkeypatch.setenv("LLM_QUALITY_FLOOR", "high")
+    r = LLMRouter()
+    keys = [p.provider_key for p in r._fallback_candidates("code_review") if p is not None]
+    assert "groq_8b" not in keys
+    assert "openrouter" not in keys
+    assert "groq_70b" in keys
+
+    monkeypatch.delenv("LLM_QUALITY_FLOOR", raising=False)
+    keys = [p.provider_key for p in r._fallback_candidates("code_review") if p is not None]
+    assert "groq_8b" in keys
+
+
+def test_model_disclosure_roundtrip():
+    from app.ai import router as router_mod
+
+    router_mod.reset_last_call()
+    assert router_mod.last_model_disclosure() == ""
+
+    router_mod._last_call.provider = "groq_70b"
+    router_mod._last_call.model = "llama-3.3-70b-versatile"
+    assert "llama-3.3-70b-versatile" in router_mod.last_model_disclosure()
+
+    router_mod.reset_last_call()
+    assert router_mod.last_model_disclosure() == ""
 
 
 # ── 6. server._authorized constant-time bearer ─────────────────────────────────

--- a/tests/test_inline_review.py
+++ b/tests/test_inline_review.py
@@ -1,0 +1,206 @@
+"""
+tests/test_inline_review.py — V6.2 inline PR reviews.
+
+Covers the pure diff-mapping helpers (app/github/patch_parser.py) and the
+_review_code flow: inline Reviews-API path, suggestion-block safety rules,
+and the fall-back-to-issue-comment guarantee.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.github.patch_parser import (
+    commentable_lines,
+    make_suggestion_block,
+    nearest_commentable,
+    parse_line_ref,
+)
+
+# A realistic unified diff: new-file line numbers 10-15.
+# 10: context, 11: added, 12: added, 13: context, 14: context (blank), 15: context
+PATCH = (
+    "@@ -8,5 +10,6 @@ def handler():\n"
+    "     token = get_token()\n"
+    "+    if token is None:\n"
+    "+        raise AuthError()\n"
+    "-    old_line_removed()\n"
+    "     do_work(token)\n"
+    "\n"
+    "     return ok\n"
+)
+
+
+class TestCommentableLines:
+
+    def test_maps_added_and_context_lines(self):
+        lines = commentable_lines(PATCH)
+        assert set(lines) == {10, 11, 12, 13, 14, 15}
+        assert lines[11] == ("    if token is None:", True)
+        assert lines[12] == ("        raise AuthError()", True)
+        assert lines[10] == ("    token = get_token()", False)
+
+    def test_deleted_lines_not_commentable(self):
+        contents = [c for c, _ in commentable_lines(PATCH).values()]
+        assert not any("old_line_removed" in c for c in contents)
+
+    def test_empty_or_headerless_patch(self):
+        assert commentable_lines("") == {}
+        assert commentable_lines("+def login(): pass") == {}  # no @@ hunk header
+
+    def test_multiple_hunks(self):
+        patch = (
+            "@@ -1,2 +1,2 @@\n"
+            "+first\n"
+            " ctx\n"
+            "@@ -10,2 +20,2 @@\n"
+            "+second\n"
+            " ctx2\n"
+        )
+        lines = commentable_lines(patch)
+        assert lines[1] == ("first", True)
+        assert lines[20] == ("second", True)
+
+
+class TestParseLineRef:
+
+    def test_variants(self):
+        assert parse_line_ref(42) == 42
+        assert parse_line_ref("42") == 42
+        assert parse_line_ref("~42") == 42
+        assert parse_line_ref("42-45") == 42
+        assert parse_line_ref("around line 40") == 40
+        assert parse_line_ref("?") is None
+        assert parse_line_ref("") is None
+        assert parse_line_ref(None) is None
+        assert parse_line_ref(0) is None
+
+
+class TestNearestCommentable:
+
+    def test_exact_and_snap(self):
+        lines = commentable_lines(PATCH)
+        assert nearest_commentable(11, lines) == 11
+        assert nearest_commentable(9, lines) == 10   # snaps up within distance
+        assert nearest_commentable(50, lines) is None  # too far
+
+    def test_prefers_added_over_context_on_tie(self):
+        lines = commentable_lines(PATCH)
+        # target 12: line 12 itself (added). target 13 is context; equidistant
+        # 12(added) and 14(context) from target 13 → prefers... 13 is exact.
+        # Construct a real tie: target between 11 (added) and 13 (context)? 12 is
+        # added and exact. Use distance-1 tie: target 13 has exact match; use
+        # synthetic map instead.
+        synthetic = {5: ("ctx", False), 7: ("added", True)}
+        assert nearest_commentable(6, synthetic) == 7  # tie → added wins
+
+    def test_none_target(self):
+        assert nearest_commentable(None, commentable_lines(PATCH)) is None
+
+
+class TestSuggestionBlock:
+
+    def test_single_line_fix_on_added_line(self):
+        lines = commentable_lines(PATCH)
+        block = make_suggestion_block("raise AuthError('no token')", 12, lines)
+        assert block.startswith("```suggestion\n")
+        # Indentation of the original line is preserved
+        assert "        raise AuthError('no token')" in block
+
+    def test_multiline_fix_refused(self):
+        lines = commentable_lines(PATCH)
+        assert make_suggestion_block("a\nb", 11, lines) == ""
+
+    def test_context_line_refused(self):
+        lines = commentable_lines(PATCH)
+        assert make_suggestion_block("do_work(token, retry=True)", 13, lines) == ""
+
+    def test_identical_content_refused(self):
+        lines = commentable_lines(PATCH)
+        assert make_suggestion_block("if token is None:", 11, lines) == ""
+
+    def test_unknown_line_refused(self):
+        assert make_suggestion_block("x = 1", 99, commentable_lines(PATCH)) == ""
+
+
+# ── _review_code integration ──────────────────────────────────────────────────
+
+
+def _cfg():
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda *a, **kw: kw.get("default", True)
+    cfg.footer = ""
+    return cfg
+
+
+def _review_with_issue(line_ref="11", fix="if token is None:  # check"):
+    return {
+        "score": 6,
+        "summary": "Needs a guard",
+        "issues": [
+            {"severity": "major", "line": line_ref, "issue": "missing null check", "fix": fix}
+        ],
+        "confidence": 0.9,
+    }
+
+
+def _files():
+    return [{"filename": "app/auth.py", "patch": PATCH, "additions": 2, "deletions": 1}]
+
+
+def _run_review(review, post_mock):
+    from app.ai.providers.base import LLMResponse
+
+    meta = LLMResponse(text="ok", provider="groq_70b", model="llama", total_tokens=10)
+    with patch("app.handlers.pull_request.router.ask", return_value=(review, meta)), \
+         patch("app.handlers.pull_request.validate_code_review", return_value=review), \
+         patch("app.handlers.pull_request.gh_post", post_mock):
+        from app.handlers.pull_request import _review_code
+
+        pr = {"head": {"sha": "abc1234"}}
+        _review_code(pr, "org/repo", 1, _files(), "tok", _cfg(), MagicMock(), "", MagicMock())
+
+
+class TestReviewCodeInline:
+
+    def test_mappable_issue_posts_pull_review_with_line_comment(self):
+        post = MagicMock()
+        _run_review(_review_with_issue(), post)
+
+        post.assert_called_once()
+        path, _token, payload = post.call_args[0]
+        assert path == "/repos/org/repo/pulls/1/reviews"
+        assert payload["event"] == "COMMENT"
+        assert payload["commit_id"] == "abc1234"
+        [comment] = payload["comments"]
+        assert comment["path"] == "app/auth.py"
+        assert comment["line"] == 11
+        assert comment["side"] == "RIGHT"
+        assert "MAJOR" in comment["body"]
+        assert "_fallback_md" not in comment  # internal key stripped before POST
+
+    def test_unmappable_issue_stays_in_issue_comment(self):
+        post = MagicMock()
+        _run_review(_review_with_issue(line_ref="500"), post)  # far outside diff
+
+        post.assert_called_once()
+        path, _token, payload = post.call_args[0]
+        assert path == "/repos/org/repo/issues/1/comments"  # classic path
+        assert "missing null check" in payload["body"]
+
+    def test_reviews_api_rejection_falls_back_with_findings(self):
+        from app.github.client import GitHubError
+
+        post = MagicMock(side_effect=[GitHubError("422 line not in diff", 422), {"id": 1}])
+        _run_review(_review_with_issue(), post)
+
+        assert post.call_count == 2
+        second_path, _tok, second_payload = post.call_args_list[1][0]
+        assert second_path == "/repos/org/repo/issues/1/comments"
+        assert "### Findings" in second_payload["body"]
+        assert "missing null check" in second_payload["body"]
+
+    def test_committable_suggestion_for_single_line_fix_on_added_line(self):
+        post = MagicMock()
+        _run_review(_review_with_issue(fix="if token is None or token == '':"), post)
+
+        [comment] = post.call_args[0][2]["comments"]
+        assert "```suggestion" in comment["body"]

--- a/tests/test_learning_wiring.py
+++ b/tests/test_learning_wiring.py
@@ -1,0 +1,112 @@
+"""
+tests/test_learning_wiring.py — V6.2
+
+The learning module (app/core/learning.py) existed unit-tested but UNWIRED for
+three releases. These tests pin the actual wiring:
+
+  record:  /apply (PR opened from a bot fix)  → record_fix_accepted
+           /merge (bot autofix branch merged) → record_autofix_merged
+  recall:  /fix prompt includes get_pattern_summary(repo) when non-empty
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestApplyRecordsAcceptance:
+
+    def _gh_get_side_effect(self, path, token):
+        if path.startswith("/repos/o/r/branches/"):
+            return {"name": "fix/bot-issue-42"}
+        if path == "/repos/o/r":
+            return {"default_branch": "main"}
+        if path.startswith("/repos/o/r/pulls?"):
+            return []
+        raise AssertionError(f"unexpected gh_get {path}")
+
+    def test_apply_records_fix_accepted(self):
+        from app.handlers.comments import publisher
+
+        with patch.object(publisher, "gh_get", side_effect=self._gh_get_side_effect), \
+             patch.object(publisher, "gh_post", return_value={"number": 7, "title": "t", "html_url": "u"}), \
+             patch("app.core.learning.record_fix_accepted") as rec:
+            out = publisher.cmd_apply("o/r", 42, "tok", "fix/bot-issue-42")
+
+        assert "PR Created" in out
+        rec.assert_called_once_with("o/r", 42, "autofix")
+
+    def test_apply_learning_failure_does_not_break_pr_creation(self):
+        from app.handlers.comments import publisher
+
+        with patch.object(publisher, "gh_get", side_effect=self._gh_get_side_effect), \
+             patch.object(publisher, "gh_post", return_value={"number": 7, "title": "t", "html_url": "u"}), \
+             patch("app.core.learning.record_fix_accepted", side_effect=RuntimeError("redis down")):
+            out = publisher.cmd_apply("o/r", 42, "tok", "fix/bot-issue-42")
+
+        assert "PR Created" in out  # learning is best-effort, never fatal
+
+
+class TestMergeRecordsAutofixOutcome:
+
+    def _run_merge(self, head_branch, record_mock):
+        from app.handlers.comments import publisher
+
+        pr = {"head": {"sha": "abc", "ref": head_branch}, "base": {"ref": "main"}}
+        guard_ok = MagicMock(passed=True)
+
+        with patch.object(publisher, "gh_get", side_effect=[pr, [], {"check_runs": []}]), \
+             patch.object(publisher, "gh_put", return_value={"merged": True, "sha": "deadbeef1234"}), \
+             patch.object(publisher, "gh_delete"), \
+             patch("app.core.guardrails.check_pr_auto_merge", return_value=guard_ok), \
+             patch("app.core.learning.record_autofix_merged", record_mock):
+            return publisher.cmd_merge(
+                "o/r", 99, {"pull_request": {}}, "tok", "alice", MagicMock()
+            )
+
+    def test_merge_of_bot_branch_records(self):
+        rec = MagicMock()
+        out = self._run_merge("fix/bot-issue-42", rec)
+        assert "Merged" in out
+        rec.assert_called_once_with("o/r", 99, 42)
+
+    def test_merge_of_regular_branch_does_not_record(self):
+        rec = MagicMock()
+        out = self._run_merge("feat/human-work", rec)
+        assert "Merged" in out
+        rec.assert_not_called()
+
+
+class TestFixPromptRecallsPatterns:
+
+    def _capture_fix_prompt(self, pattern_summary):
+        from app.handlers.comments import generator
+
+        captured = {}
+
+        def _fake_ask(system, user, **kw):
+            captured["user"] = user
+            return ({"root_cause": "x", "fix": "y", "explanation": "z", "test": "t",
+                     "confidence": 0.9}, MagicMock())
+
+        with patch("app.handlers.comments.router") as mock_router, \
+             patch("app.core.learning.get_pattern_summary", return_value=pattern_summary):
+            mock_router.ask.side_effect = _fake_ask
+            generator.cmd_fix("bug title", "some context", repo="o/r")
+        return captured["user"]
+
+    def test_learned_patterns_injected(self):
+        prompt = self._capture_fix_prompt(" prefers-pathlib=True")
+        assert "Repo conventions (learned from previously accepted fixes)" in prompt
+        assert "prefers-pathlib=True" in prompt
+
+    def test_no_patterns_no_noise(self):
+        prompt = self._capture_fix_prompt("")
+        assert "Repo conventions" not in prompt
+
+    def test_no_repo_arg_skips_learning_entirely(self):
+        from app.handlers.comments import generator
+
+        with patch("app.handlers.comments.router") as mock_router, \
+             patch("app.core.learning.get_pattern_summary") as gps:
+            mock_router.ask.return_value = ({"root_cause": "x"}, MagicMock())
+            generator.cmd_fix("t", "c")  # no repo
+        gps.assert_not_called()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -27,11 +27,20 @@ _req.exceptions.Timeout = TimeoutError
 sys.modules.setdefault('requests', _req)
 sys.modules.setdefault('requests.adapters', _req.adapters)
 sys.modules.setdefault('requests.exceptions', _req.exceptions)
+# Mock ONLY the deps that are genuinely missing. Blanket-mocking installed
+# modules (this list used to include flask unconditionally) poisoned
+# sys.modules for every later-collected test file and permanently skipped 21
+# real-Flask tests. Real module available → use it; missing → mock it.
+import importlib
+
 for _m in ['structlog','redis','groq','google','google.generativeai',
            'flask_limiter','flask_limiter.util','apscheduler',
            'apscheduler.schedulers','apscheduler.schedulers.background',
            'sentence_transformers','qdrant_client','scipy','flask','flask.logging']:
-    sys.modules.setdefault(_m, MagicMock())
+    try:
+        importlib.import_module(_m)
+    except ImportError:
+        sys.modules.setdefault(_m, MagicMock())
 
 # Determine which module name GitHub used
 _mcp_server_path = _ROOT / "app" / "mcp" / "mcp_server.py"
@@ -428,6 +437,62 @@ class TestToolsCallDispatch:
             mod.TOOL_HANDLERS["explain_code"] = original
         assert status == 500
         assert "boom" in resp["error"]["message"]
+
+
+class TestMCPNamedKeys:
+    """V6.2: MCP_API_KEYS name:key pairs — per-client revocation + audit labels."""
+
+    def _env(self, **vars):
+        import os
+        return patch.dict(os.environ, vars, clear=False)
+
+    def test_named_key_authenticates(self):
+        mod = _import_mcp()
+        with self._env(MCP_API_KEY="", MCP_API_KEYS="laptop:tok-a,ci:tok-b"):
+            resp, status = mod.handle_mcp_request("tools/list", {}, "tok-b")
+        assert status == 200
+
+    def test_wrong_token_rejected_401(self):
+        mod = _import_mcp()
+        with self._env(MCP_API_KEY="", MCP_API_KEYS="laptop:tok-a"):
+            resp, status = mod.handle_mcp_request("tools/list", {}, "tok-WRONG")
+        assert status == 401
+
+    def test_legacy_and_named_coexist(self):
+        mod = _import_mcp()
+        with self._env(MCP_API_KEY="legacy-tok", MCP_API_KEYS="ci:tok-b"):
+            assert mod.handle_mcp_request("tools/list", {}, "legacy-tok")[1] == 200
+            assert mod.handle_mcp_request("tools/list", {}, "tok-b")[1] == 200
+
+    def test_no_keys_at_all_fails_closed_503(self):
+        mod = _import_mcp()
+        with self._env(MCP_API_KEY="", MCP_API_KEYS=""):
+            resp, status = mod.handle_mcp_request("tools/list", {}, "anything")
+        assert status == 503
+
+    def test_malformed_entry_skipped_not_fatal(self):
+        """A typo'd entry must not break the valid one — and must never
+        accidentally authenticate."""
+        mod = _import_mcp()
+        with self._env(MCP_API_KEY="", MCP_API_KEYS="brokenentry,ci:tok-b"):
+            assert mod.handle_mcp_request("tools/list", {}, "tok-b")[1] == 200
+            assert mod.handle_mcp_request("tools/list", {}, "brokenentry")[1] == 401
+
+    def test_audit_metric_labeled_by_client(self):
+        from app.core.metrics import metrics
+        mod = _import_mcp()
+        with self._env(MCP_API_KEY="", MCP_API_KEYS="ci:tok-b"):
+            before = metrics.get("mcp.calls.ci")
+            original = mod.TOOL_HANDLERS["explain_code"]
+            mod.TOOL_HANDLERS["explain_code"] = lambda _: "ok"
+            try:
+                _, status = mod.handle_mcp_request(
+                    "tools/call", {"name": "explain_code", "arguments": {"code": "x"}}, "tok-b"
+                )
+            finally:
+                mod.TOOL_HANDLERS["explain_code"] = original
+        assert status == 200
+        assert metrics.get("mcp.calls.ci") == before + 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements every actionable finding from the deep-audit feedback round. **894 tests passed / 0 skipped** (was 826 / 21 permanently skipped), ruff lint + format clean. Everything below was verified by running it.

## Product

### 1. Inline PR reviews (biggest UX gap vs competitors — closed)
Findings now post as a **real GitHub Review with line-anchored comments**, not a wall-of-text issue comment.
- New [`app/github/patch_parser.py`](app/github/patch_parser.py): pure, unit-tested mapping of the AI's approximate line refs ("~42", "42-45") onto legally-commentable diff lines — nearest-line snapping with added-line preference.
- Committable ```suggestion blocks — emitted **only** for single-line fixes on added lines that differ from the current content (with indentation preserved); anything else renders as a fenced code block.
- **Never loses a review**: if the Reviews API rejects the payload (422), automatic fallback to the classic issue comment *including* the findings that would have been inline. 15 new tests.

### 2. AI evals — the product is now measured, not vibes ([evals/](evals/))
- Golden `/fix` issues (off-by-one, mutable default, unclosed handle, tz-naive compare, check-then-act race, swallowed exception) and PR diffs with planted bugs (SQL injection, hardcoded prod credential, N+1, path traversal) **plus a clean-diff case that penalizes over-flagging**.
- Cases run through the **real production code paths** (`cmd_fix`, `_review_code` with `gh_post` captured) — prompt edits can't drift away from what's measured. Deterministic regex scorers; no LLM judge.
- `python -m evals.run` (exit 2 on a test key rather than burning quota) + manual **Evals** workflow (`workflow_dispatch`, uses `GROQ_API_KEY` secret). The harness itself has 9 unit tests.
- War story: the original planted Stripe key was realistic enough that **GitHub push protection blocked the push** — re-planted with a non-matching pattern and documented why in the case file.

### 3. Honest AI output
- **Model disclosure**: every posted comment names the model that produced it (per-thread record, reset per event so reused pool threads can't disclose a stale model).
- **Quality floor** (`LLM_QUALITY_FLOOR=high`, off by default): reviews/fixes/analyses refuse basic-tier providers (Groq 8B / OpenRouter) on both the selection *and* fallback paths — an honest "providers down" instead of a silent 8B review. Fast tasks (labels, lint) unaffected.

### 4. Learning loop wired (was shipped unit-tested-but-unused since V6.0)
`/apply` and merging a `fix/bot-issue-*` branch record acceptance → future `/fix` prompts inject `get_pattern_summary(repo)`. Best-effort: learning failures can never break a command. 7 new tests.

## Hardening

| Issue (from audit) | Fix |
|---|---|
| Command rate limit **failed open** when Redis down | Bounded in-memory sliding window (5000-key hard cap, expired-window pruning, deny-at-capacity) — limit enforced during outages; observable via `ratelimit.redis_fallback` |
| One shared MCP key, no audit trail | `MCP_API_KEYS="laptop:tok1,ci:tok2"` named keys + legacy key coexist; constant-time compares over *every* candidate (no early-exit timing); `mcp.audit` log lines + per-client metrics; arguments never logged (they can contain code) |
| 25MB `noeviction` Redis fills → writes fail invisibly | `redis_memory` watermark on `/health`, warn ≥80% (`REDIS_MEMORY_WARN_PCT`) |
| `/` endpoint still said "AI Repo Manager" | Fixed; dashboard shell gets `robots noindex` |

**Retraction**: the audit's "public dashboard leaks ops data" claim was **verified false** — the shell is data-free and polls the auth-gated `/health` with an operator-pasted token. Noted here for the record.

## Tests

- **The 21 permanently-skipped tests now run and pass**: `test_mcp.py` / `test_commands_fixed.py` blanket-mocked `flask` in `sys.modules` at collection, poisoning every later file. They now mock only genuinely-missing modules (import-first). Skip guards remain as safety nets.
- `service.py` line budget consciously 260→265 (disclosure wiring), history documented in the test.

## Docs

README leads with the self-hosted/local-LLM privacy wedge; "no event ever silently lost" corrected (it contradicted its own fallback paragraph four lines later); demo labeled as simulated with a pointer to evals; V6.2.0 changelog. CONTRIBUTING gains an evals section; `.env.example` documents `MCP_API_KEYS` + `LLM_QUALITY_FLOOR`.

## Version

6.1.1 → **6.2.0** across the SSOT and all synced manifests. After merge: `git tag v6.2.0 && git push origin v6.2.0`.

## Test plan
- [x] 894 passed / 0 skipped / 0 failed locally (Python 3.14)
- [x] ruff check + format clean (incl. evals/)
- [x] `python -m evals.run` exits 2 on test key (no quota burn); harness unit-tested
- [x] `github-autopilot --version` → 6.2.0
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
