### PR TITLE
Fix comment-arg casing, /apply PR-existence check, and CI pattern alerts

### DIFF
--- a/app/handlers/ci.py
+++ b/app/handlers/ci.py
@@ -3,8 +3,8 @@ app/handlers/ci.py
 V4 Sprint 4: CI check_run event handler.
 
 Triggers when a CI check completes.
-On failure: posts analysis comment with AI-suggested fix.
-On success: posts encouragement only if previously failed.
+On failure: posts an AI analysis comment with a suggested fix, and flags
+recurring failures (same check failing 3+ times in 24h) as a pattern alert.
 """
 
 import logging
@@ -91,7 +91,18 @@ def handle(payload: dict):
         if fix_text and not fix_text.startswith("-"):
             fix_text = "- " + fix_text.replace("\n", "\n- ")
 
-        comment = f"## {cat_emoji} CI Failure — `{check_name}`\n\n**Root cause:** {r.get('root_cause', 'See details below')}\n\n### Fix\n{fix_text}\n{flaky_note}\n\n---\n*🤖 GitHub Autopilot — CI Analysis*{config.footer}"
+        # Recurring-failure detection: if this same check has now failed 3 times
+        # in 24h, surface a pattern alert so maintainers know it isn't a one-off.
+        root_cause = r.get("root_cause", "See details below")
+        pattern_note = ""
+        if _track_failure_pattern(repo, check_name, root_cause):
+            pattern_note = (
+                f"\n\n> 🔁 **Recurring failure** — `{check_name}` has failed "
+                "3+ times in the last 24h. This looks like a persistent issue, "
+                "not a flake."
+            )
+
+        comment = f"## {cat_emoji} CI Failure — `{check_name}`\n\n**Root cause:** {root_cause}\n\n### Fix\n{fix_text}\n{flaky_note}{pattern_note}\n\n---\n*🤖 GitHub Autopilot — CI Analysis*{config.footer}"
 
         gh_post(f"/repos/{repo}/issues/{pr_number}/comments", token, {"body": comment})
         log_ctx.done(f"CI failure comment posted PR #{pr_number}")

--- a/app/handlers/comments/publisher.py
+++ b/app/handlers/comments/publisher.py
@@ -161,7 +161,7 @@ def cmd_apply(
             raise
 
         # Check for existing open PR
-        owner = repo.split("/")[1] if "/" in repo else repo
+        owner = repo.split("/")[0] if "/" in repo else repo
         existing = gh_get(f"/repos/{repo}/pulls?head={owner}:{branch}&state=open&per_page=5", token)
         if isinstance(existing, list) and existing:
             pr = existing[0]

--- a/app/handlers/comments/service.py
+++ b/app/handlers/comments/service.py
@@ -104,8 +104,8 @@ def handle_comment_event(payload: dict) -> None:
         )
         return
 
-    # ── Command arguments (text after the command) ─────────────────────────
-    cmd_args = body.lower().split(cmd, 1)[-1].strip() if cmd in body.lower() else ""
+    idx = body.lower().find(cmd)  # slice ORIGINAL body so args keep their case
+    cmd_args = body[idx + len(cmd) :].strip() if idx != -1 else ""
 
     # ── Context building ──────────────────────────────────────────────────
     context = f"Title: {issue.get('title', '')}\nBody: {(issue.get('body') or '')[:1500]}"

--- a/tests/test_comments_package.py
+++ b/tests/test_comments_package.py
@@ -248,6 +248,35 @@ class TestRateLimiting:
         dispatcher._local_cmd_counts.clear()
 
 
+class TestApplyPrExistenceCheck:
+    """Regression: the open-PR lookup must filter by head=<owner>:<branch>.
+    A prior bug used repo.split('/')[1] (the repo NAME) as the owner, so the
+    filter never matched and /apply could open duplicate PRs."""
+
+    def test_head_filter_uses_owner_not_repo_name(self):
+        from unittest.mock import patch
+        from app.handlers.comments import publisher as P
+
+        seen = {}
+
+        def fake_gh_get(url, token=None):
+            if url.startswith("/repos/octo/proj/pulls?head="):
+                seen["url"] = url
+                # Report an existing PR so the function returns early.
+                return [{"number": 7, "title": "existing", "html_url": "u"}]
+            if url == "/repos/octo/proj":
+                return {"default_branch": "main"}
+            if url.startswith("/repos/octo/proj/branches/"):
+                return {"name": "fix/bot-issue-1"}
+            return {}
+
+        with patch.object(P, "gh_get", side_effect=fake_gh_get):
+            res = P.cmd_apply("octo/proj", 1, "token", "fix/bot-issue-1")
+
+        assert "head=octo:fix/bot-issue-1" in seen.get("url", "")
+        assert "PR Already Exists" in res
+
+
 class TestFileSize:
 
     def test_no_single_file_exceeds_500_lines(self):

--- a/tests/test_comments_service_integration.py
+++ b/tests/test_comments_service_integration.py
@@ -65,7 +65,7 @@ class TestHappyPath:
         assert dispatch.called
         common_mocks["post"].assert_called_once()
         posted_path, _token, body = common_mocks["post"].call_args[0]
-        assert "/repos/test/repo/issues/1/comments" == posted_path
+        assert posted_path == "/repos/test/repo/issues/1/comments"
         assert "Do the thing." in body["body"]
         assert "requested by @alice" in body["body"]
 
@@ -137,6 +137,27 @@ class TestRateLimitAndAuthorization:
         _, _, body = common_mocks["post"].call_args[0]
         assert "Permission Denied" in body["body"]
         assert "needs write access" in body["body"]
+
+
+class TestCommandArgs:
+    def test_args_preserve_original_case(self, common_mocks):
+        """Regression: args must NOT be lowercased — they were sliced from
+        body.lower(), which mangled /notify messages and branch names."""
+        with patch(
+            "app.handlers.comments.service._dispatch", return_value="ok"
+        ) as dispatch:
+            handle_comment_event(_payload(body="/notify Deploy FAILED on Prod"))
+
+        assert dispatch.called
+        assert dispatch.call_args.kwargs["cmd_args"] == "Deploy FAILED on Prod"
+
+    def test_args_empty_when_no_trailing_text(self, common_mocks):
+        with patch(
+            "app.handlers.comments.service._dispatch", return_value="ok"
+        ) as dispatch:
+            handle_comment_event(_payload(body="/fix"))
+
+        assert dispatch.call_args.kwargs["cmd_args"] == ""
 
 
 class TestDispatchOutcomes:

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import base64
 from unittest.mock import MagicMock, patch
@@ -272,12 +271,12 @@ def test_metrics_collector():
     collector.increment("test.counter", 2)
     assert collector.get("test.counter") == 2
     assert collector.get("nonexistent") == 0
-    
+
     snap = collector.snapshot()
     assert snap["test.counter"] == 2
     assert "uptime_seconds" in snap
     assert "uptime_human" in snap
-    
+
     collector.reset()
     assert collector.get("test.counter") == 0
 
@@ -285,17 +284,17 @@ def test_thread_pool():
     # Test pool initialization and config
     pool = tp_mod.get_pool()
     assert pool is not None
-    
+
     # Test pool stats
     stats = tp_mod.pool_stats()
     assert stats["max_workers"] == tp_mod.MAX_DISPATCH_WORKERS
     assert stats["queue_capacity"] == 50
-    
+
     # Test bounded dispatch
     called = []
     def sample_task():
         called.append(True)
-        
+
     future = tp_mod.dispatch(sample_task)
     assert not tp_mod.is_saturated(future)
     future.result() # Wait for task
@@ -303,7 +302,7 @@ def test_thread_pool():
 
     # Test saturation sentinel
     assert tp_mod.is_saturated(tp_mod._SATURATED)
-    
+
     # Test shutdown
     tp_mod.shutdown(wait=True)
     assert tp_mod._pool is None
@@ -315,26 +314,26 @@ def test_licenses_scan(mock_get):
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"info": {"license": "GPL-3.0 License"}}
     mock_get.return_value = mock_resp
-    
+
     res = lic_mod.check_package_license("gpl-pkg")
     assert res["package"] == "gpl-pkg"
     assert res["risk"] == "copyleft"
-    
+
     # Scan requirements.txt content
     findings = lic_mod.scan_requirements("gpl-pkg==1.0")
     assert len(findings) == 1
     assert findings[0]["package"] == "gpl-pkg"
-    
+
     # Format findings
     formatted = lic_mod.format_findings(findings)
     assert "gpl-pkg" in formatted
     assert "copyleft" in formatted
-    
+
     # Non-copyleft case
     mock_resp.json.return_value = {"info": {"license": "MIT"}}
     res_mit = lic_mod.check_package_license("mit-pkg")
     assert res_mit["risk"] == "safe"
-    
+
     # Empty findings formatting
     empty_formatted = lic_mod.format_findings([])
     assert "permissive" in empty_formatted
@@ -351,23 +350,23 @@ def test_system_health(mock_get_redis, mock_redis_avail, mock_gh_status, mock_br
         "groq": {"state": "closed"},
         "gemini": {"state": "open"} # degraded
     }
-    
+
     # Mock redis instance for record_latency
     mock_redis = MagicMock()
     mock_redis.get.return_value = None
     mock_get_redis.return_value = mock_redis
-    
+
     # Record latency
     hc_mod.record_latency("groq", 150)
     mock_redis.set.assert_called()
-    
+
     # Get system health
     health = hc_mod.get_system_health()
     assert health["status"] == "partial"
     assert health["is_degraded"] is True
     assert health["providers"]["gemini"]["is_degraded"] is True
     assert health["providers"]["groq"]["is_degraded"] is False
-    
+
     # Get degraded message
     msg = hc_mod.get_degraded_message()
     assert "gemini" in msg

--- a/tests/test_hardening_v6.py
+++ b/tests/test_hardening_v6.py
@@ -275,7 +275,6 @@ def _req(auth_value):
 
 
 def test_authorized_open_when_no_token(monkeypatch):
-    import importlib
     import server
     monkeypatch.setattr(server, "METRICS_TOKEN", "")
     assert server._authorized(_req("")) is True

--- a/tests/test_integration_privacy_and_brain.py
+++ b/tests/test_integration_privacy_and_brain.py
@@ -14,7 +14,6 @@ single internal method.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_ollama_local.py
+++ b/tests/test_ollama_local.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import app.ai.circuit_breaker as cb
-from app.ai.providers.base import LLMResponse
 from app.ai.providers.ollama import OllamaProvider, is_configured
 from app.ai.router import LLMRouter
 

--- a/tests/test_week1_fixes.py
+++ b/tests/test_week1_fixes.py
@@ -303,9 +303,8 @@ class TestCLIWorkerConfig:
         sys.argv = ["github-autopilot", "--version"]
         buf = io.StringIO()
         try:
-            with pytest.raises(SystemExit) as exc:
-                with contextlib.redirect_stdout(buf):
-                    cli.main()
+            with pytest.raises(SystemExit) as exc, contextlib.redirect_stdout(buf):
+                cli.main()
         finally:
             sys.argv = argv_backup
         assert exc.value.code == 0


### PR DESCRIPTION
Three defects found while scanning the comments and CI-check features:

- comments/service.py: command arguments were sliced from body.lower(),
  silently lowercasing user input (e.g. /notify messages, branch names).
  Now the command is located case-insensitively but the argument is sliced
  from the original body so its case is preserved.

- comments/publisher.py (/apply): the open-PR lookup built the head filter
  from repo.split("/")[1] — the repo NAME, not the owner — so the filter
  never matched and /apply could open duplicate PRs. Use index [0] (owner).

- handlers/ci.py: the recurring-failure detector (_track_failure_pattern)
  was defined and unit-tested but never wired into handle(), so the Sprint-5
  pattern alert never fired. It is now invoked when building the failure
  comment, and the module docstring is corrected to match actual behavior.

Adds regression tests for the two behavior bugs (both confirmed to fail
before the fix) and tidies auto-fixable ruff warnings in tests/.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UBewWrqc7VMzzRAwoeM9Ai