### PR TITLE
Fix: harden prompt injection defense with NFKC, zero-width strip, whitespace collapse, and fail-closed critical handling

### DIFF
--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -182,20 +182,34 @@ class LLMRouter:
         try:
             from app.core.sanitizer import sanitize_user_input
 
-            return sanitize_user_input(text)
+            result = sanitize_user_input(text)
+            if result is None:
+                # Fail-closed: critical injection detected
+                return "[INPUT_REJECTED_DUE_TO_INJECTION]"
+            return result
         except Exception:
-            # Fallback: basic injection filter
-            for pattern in [
-                "ignore all previous",
-                "you are now",
-                "jailbreak",
-                "disregard",
-                "forget your instructions",
-            ]:
-                lower = text.lower()
-                if pattern in lower:
-                    idx = lower.index(pattern)
-                    text = text[:idx] + "[FILTERED]" + text[idx + len(pattern) :]
+            # Fallback: hardened injection filter
+            import re
+            import unicodedata
+            try:
+                text = unicodedata.normalize("NFKC", text)
+            except Exception:
+                pass
+            text = re.sub(r"[\u200b\u200c\u200d\u2060\ufeff]", "", text)
+            text = re.sub(r"\s+", " ", text)
+            patterns = [
+                r"ignore\s+(all\s+)?previous\s+instructions?",
+                r"you\s+are\s+now",
+                r"jailbreak",
+                r"disregard",
+                r"forget\s+your\s+instructions",
+            ]
+            lower = text.lower()
+            for pat in patterns:
+                m = re.search(pat, lower)
+                if m:
+                    text = text[:m.start()] + "[FILTERED]" + text[m.end():]
+                    lower = text.lower()
             return text
 
     def _select_provider(self, task: str, context_tokens: int = 0) -> LLMProvider:

--- a/app/core/sanitizer.py
+++ b/app/core/sanitizer.py
@@ -71,6 +71,7 @@ def sanitize_user_input(text: str, max_chars: int = 8_000) -> str | None:
             text = new_text
             if label in critical_labels:
                 log.warning(f"sanitizer.critical_injection_detected label={label}")
+                return "[INPUT_REJECTED_DUE_TO_INJECTION]"
                 return None
 
     if hits:

--- a/app/core/sanitizer.py
+++ b/app/core/sanitizer.py
@@ -72,7 +72,6 @@ def sanitize_user_input(text: str, max_chars: int = 8_000) -> str | None:
             if label in critical_labels:
                 log.warning(f"sanitizer.critical_injection_detected label={label}")
                 return "[INPUT_REJECTED_DUE_TO_INJECTION]"
-                return None
 
     if hits:
         log.warning(f"sanitizer.injection_detected patterns={hits}")

--- a/app/core/sanitizer.py
+++ b/app/core/sanitizer.py
@@ -36,12 +36,14 @@ _INJECTION_PATTERNS: list[tuple[re.Pattern, str]] = [
 ]
 
 
-def sanitize_user_input(text: str, max_chars: int = 8_000) -> str:
+def sanitize_user_input(text: str, max_chars: int = 8_000) -> str | None:
     """
     Sanitize text from user-controlled sources (GitHub webhook payloads).
-    Applies Unicode normalization + injection pattern replacement.
+    Applies Unicode normalization, zero-width stripping, whitespace collapse,
+    and injection pattern replacement.
 
-    Does NOT raise. Returns sanitized string.
+    Returns sanitized string, or None if a critical-severity injection is
+    detected (fail-closed policy).
     """
     if not text:
         return ""
@@ -53,13 +55,23 @@ def sanitize_user_input(text: str, max_chars: int = 8_000) -> str:
     with contextlib.suppress(Exception):
         text = unicodedata.normalize("NFKC", text)
 
+    # Strip zero-width / invisible characters used for evasion
+    text = re.sub(r"[\u200b\u200c\u200d\u2060\ufeff]", "", text)
+
+    # Collapse whitespace (newlines/tabs -> space) so 'ignore\nprevious' matches
+    text = re.sub(r"\s+", " ", text)
+
     # Pattern replacement
     hits = []
+    critical_labels = {"JAILBREAK", "EXFIL"}
     for pattern, label in _INJECTION_PATTERNS:
         new_text, n = pattern.subn(f"[{label}]", text)
         if n:
             hits.append(label)
             text = new_text
+            if label in critical_labels:
+                log.warning(f"sanitizer.critical_injection_detected label={label}")
+                return None
 
     if hits:
         log.warning(f"sanitizer.injection_detected patterns={hits}")


### PR DESCRIPTION
## Summary
The _sanitize() fallback in router.py uses trivial substring matching that is bypassable, and the primary sanitizer lacks zero-width stripping, whitespace collapse, and fail-closed critical handling. We harden the fallback and add a hardened sanitize_user_input with those defenses plus fail-closed behavior.

**Fixes:** https://github.com/Shweta-Mishra-ai/github-autopilot/issues/76

---

### Changes Made
- `app/core/sanitizer.py`
- `app/ai/router.py`
