### PR TITLE
Enforce the configuration the product documents

### DIFF
--- a/.ai-repo-manager.yml
+++ b/.ai-repo-manager.yml
@@ -67,35 +67,17 @@ commands:
       - merge
       - release
       - rollback
-  enabled:
-    # Code Quality
-    - fix
-    - autofix
-    - apply
-    - improve
-    - refactor
-    - perf
-    # Understanding
-    - explain
-    - summarize
-    - arch
-    - impact
-    - gaps
-    - ci
-    # Documentation & Release
-    - docs
-    - test
-    - changelog
-    - release
-    - version
-    - runtests
-    # Security & Health
-    - security
-    - secfull
-    - health
-    # Operations
-    - merge
-    - rollback
-    - report
-    - budget
-    - notify
+      # Writes to persistent repo memory, which is injected into every later
+      # AI prompt. Ungated, any commenter could poison that context.
+      - ignore
+
+  # `enabled` is an optional allow-list. Omitted here, which means every
+  # command stays available — the registry is not duplicated into config,
+  # because a copy goes stale and then silently disables working commands.
+  #
+  # To restrict, list only what you want:
+  #
+  # enabled:
+  #   - fix
+  #   - explain
+  #   - health

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "github-autopilot",
       "description": "Call GitHub Autopilot's AI tools (analyze PR, fix issue, scan secrets, repo health) from Claude Code via MCP.",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "source": "./plugin",
       "homepage": "https://github.com/Shweta-Mishra-ai/github-autopilot",
       "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Type any of these in a GitHub issue or PR comment:
 | `/release` | Draft GitHub release | Maintainers |
 | `/runtests` | Trigger CI workflow | Maintainers |
 | `/notify` | Send Discord/Slack alert | Maintainers |
+| `/ignore <rule>` | Teach the bot to stop flagging a pattern in this repo | Maintainers |
 | `/autofix` | Auto-apply code improvements (human-confirmed via `/apply`) | Maintainers |
 
 ---
@@ -288,7 +289,7 @@ python server.py
 ```
 
 ```bash
-pytest tests/ -v              # 840+ tests, ~75% coverage — exact count lives in the CI badge
+pytest tests/ -v              # 1038 tests, 79% coverage — the CI badge is the live number
 ruff check app/               # lint
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Install the GitHub App on your repos, then:
 
 ```bash
 curl https://github-autopilot-1.onrender.com/ping
-# → {"status": "ok", "version": "7.0.0"}
+# → {"status": "ok", "version": "7.1.0"}
 ```
 
 > **Cold starts** — the demo instance runs on Render's free tier. A scheduled
@@ -270,10 +270,28 @@ commands:
     maintainer_only: [merge, rollback, release]
 
 bot:
+  enabled: true               # master kill switch — false stops everything
   footer: "*Powered by GitHub Autopilot*"
+
+commands:
+  enabled: [fix, explain, health]   # optional allow-list; omit to keep all commands
 ```
 
 All keys are validated on load — bad values log a warning and fall back to safe defaults.
+
+**Config is read from your default branch, never from a pull request.** This is
+deliberate: config decides who may merge, whether auto-merge runs, and whether
+secrets are scanned, so honouring it from a PR head would let any contributor
+grant themselves those rights by editing the file inside their own PR. Config
+changes take effect once merged — the same trust boundary GitHub Actions applies
+to workflow permissions.
+
+Two behaviours worth knowing:
+
+- Omitting `commands.enabled` means *no restriction* — every command stays
+  available. It is an allow-list, not a registry, so you never have to keep it in
+  sync with new releases. An explicit `enabled: []` disables everything.
+- `bot.enabled: false` stops all handlers: PRs, issues, pushes, CI and commands.
 
 ---
 
@@ -289,7 +307,7 @@ python server.py
 ```
 
 ```bash
-pytest tests/ -v              # 1038 tests, 79% coverage — the CI badge is the live number
+pytest tests/ -v              # 1051 tests, 79% coverage — the CI badge is the live number
 ruff check app/               # lint
 ```
 
@@ -312,6 +330,18 @@ Found a vulnerability? Please email rather than opening a public issue.
 ---
 
 ## Changelog
+
+### V7.1.0 — 2026-08-03
+
+Pre-launch audit. The theme is configuration the product documented and then ignored.
+
+- **Thirteen dead config keys wired or removed.** `bot.enabled` — the documented master kill switch — had zero callers, so setting it to `false` left the bot fully active. `commands.enabled` was never enforced. `auto_merge.allowed_risk_levels` was never consulted, so a user restricting auto-merge to low-risk PRs still had high-risk ones merged. Every `notifications.on_*` toggle was ignored. `ai.primary_model` and friends sat in repo config where nothing could read them — model choice is a deployment concern (the router is a process-wide singleton), so they are now `LLM_PRIMARY_MODEL` / `LLM_FALLBACK_MODEL` env vars.
+- **`/ignore` is now maintainer-only.** It writes to persistent repo memory, which V7 injects into every later prompt, but it was ungated: any commenter on a public repo could poison the context all subsequent commands saw — stored prompt injection that outlives the comment.
+- **Per-repo AI budget is enforced.** `check_repo_rate_limit()` and `increment_repo_usage()` existed with zero callers, so `REPO_DAILY_AI_LIMIT` did nothing and one busy repository could drain the whole free-tier quota.
+- **Review targets code, not licence files.** The review budget is spent by file kind first, then change size. Previously files were taken in GitHub's alphabetical order, so a PR touching `LICENSE`/`CONTRIBUTING`/`MANIFEST` exhausted the budget before reaching a single source file — and then reported a coverage score for code it had never read.
+- **The command registry is no longer duplicated.** It lived in four places and had already drifted; `ALL_COMMANDS` is now the only source, and an absent `commands.enabled` means "no restriction" rather than "everything off".
+- Config is documented as read from the default branch, never a PR head — a trust boundary, since config decides who may merge. Pinned by a test so it is not "fixed" into a privilege-escalation hole.
+- New `tests/test_prelaunch_audit.py` checks these as classes rather than cases: every config key must be read, every `Config` helper must have a caller, any command reaching `remember()` must be gated, every command must be documented, and versions must agree across all manifests.
 
 ### V7.0.0 — 2026-07-27
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,4 +2,4 @@
 
 # Single source of truth for the application version.
 # server.py, app/mcp/mcp_server.py, and pyproject.toml all reference this.
-__version__ = "7.0.0"
+__version__ = "7.1.0"

--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -92,8 +92,15 @@ def _quality_floor_active() -> bool:
 
 class LLMRouter:
     def __init__(self):
-        self._groq_70b = GroqProvider("llama-3.3-70b-versatile")
-        self._groq_8b = GroqProvider("llama-3.1-8b-instant")
+        # Model choice is a DEPLOYMENT concern, not a per-repo one: this
+        # router is a process-wide singleton serving every installation, so a
+        # repo-level override would let one tenant pick a model that drains
+        # another's quota tier. It was previously declared in repo config
+        # (ai.primary_model) where nothing could read it.
+        self._groq_70b = GroqProvider(
+            os.environ.get("LLM_PRIMARY_MODEL", "llama-3.3-70b-versatile")
+        )
+        self._groq_8b = GroqProvider(os.environ.get("LLM_FALLBACK_MODEL", "llama-3.1-8b-instant"))
         self._gemini = None
         self._openrouter = None
         self._ollama = None

--- a/app/core/authorization.py
+++ b/app/core/authorization.py
@@ -41,6 +41,12 @@ RESTRICTED_COMMANDS = {
     "/autofix",
     "/apply",  # Auto-mutates repo state
     "/secfull",  # Sensitive report — internal data
+    # Writes to persistent repo memory, which is injected into every
+    # subsequent AI prompt. Ungated, any commenter on a public repo could
+    # poison the context every later command sees — a stored prompt-injection
+    # vector that outlives the comment. Its own docstring always said
+    # "maintainer preference"; this makes that true.
+    "/ignore",
 }
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -99,35 +99,19 @@ DEFAULTS: dict = {
         "auto_create": True,
     },
     "commands": {
-        "enabled": [
-            # V2.1
-            "fix",
-            "apply",
-            "explain",
-            "improve",
-            "test",
-            "docs",
-            "refactor",
-            "health",
-            "version",
-            "merge",
-            # V3
-            "summarize",
-            "ci",
-            "security",
-            "gaps",
-            "changelog",
-            # V4
-            "rollback",
-            "autofix",
-            "impact",
-            "perf",
-            "arch",
-            "release",
-            "runtests",
-            "secfull",
-            "budget",
-        ],
+        # NOTE: no "enabled" list here, deliberately.
+        #
+        # The command registry lives in exactly one place —
+        # app.handlers.comments.constants.ALL_COMMANDS. A copy here would be a
+        # second source of truth, and _deep_merge REPLACES lists rather than
+        # merging them, so that copy would silently become a ceiling: any
+        # command added to the registry but forgotten here would stop working
+        # the moment the list is enforced. That is exactly what happened —
+        # this list had gone stale by three commands (ignore, notify, report).
+        #
+        # An absent key means "no restriction configured" (see
+        # Config.command_enabled). Operators who want an allow-list set one in
+        # their own .ai-repo-manager.yml.
         "permissions": {
             "maintainer_only": ["merge", "release", "rollback"],
         },
@@ -224,20 +208,60 @@ class Config:
     # ── Convenience shortcuts ─────────────────────────────────────────────────
 
     def bot_enabled(self) -> bool:
+        """
+        Master kill switch. `bot.enabled: false` must stop EVERYTHING.
+
+        This had zero callers: it shipped in the sample config as the
+        documented way to turn the app off, and setting it to false left the
+        bot fully active. Every section helper below now defers to it, so the
+        switch cannot be bypassed by adding a new section later.
+        """
         return bool(self.get("bot", "enabled", default=True))
 
     def pr_enabled(self) -> bool:
-        return bool(self.get("pull_requests", "enabled", default=True))
+        return self.bot_enabled() and bool(self.get("pull_requests", "enabled", default=True))
 
     def issues_enabled(self) -> bool:
-        return bool(self.get("issues", "enabled", default=True))
+        return self.bot_enabled() and bool(self.get("issues", "enabled", default=True))
+
+    def push_enabled(self) -> bool:
+        return self.bot_enabled() and bool(self.get("push", "enabled", default=True))
+
+    def ci_enabled(self) -> bool:
+        return self.bot_enabled() and bool(self.get("ci", "enabled", default=True))
 
     def auto_merge_enabled(self) -> bool:
         return bool(self.get("auto_merge", "enabled", default=False))
 
     def command_enabled(self, cmd: str) -> bool:
-        enabled = self.get("commands", "enabled", default=[])
-        return cmd.lstrip("/") in enabled
+        """
+        True unless the operator has configured an explicit allow-list that
+        excludes `cmd`.
+
+        An ABSENT `commands.enabled` key means "no restriction configured",
+        not "everything off". That distinction matters because _deep_merge
+        replaces lists rather than merging them: any default copy of the
+        command registry would silently become a ceiling, and would disable
+        real commands the moment it fell out of date. The registry lives in
+        exactly one place — app.handlers.comments.constants.ALL_COMMANDS —
+        and is deliberately NOT duplicated into DEFAULTS.
+
+        An explicitly empty list (`enabled: []`) is honoured as "disable
+        everything", since that is an unambiguous statement of intent.
+        """
+        if not self.bot_enabled():
+            return False
+
+        enabled = self.get("commands", "enabled", default=None)
+        if enabled is None:
+            return True
+        if not isinstance(enabled, list):
+            log.warning(
+                f"config.commands_enabled_not_a_list type={type(enabled).__name__} "
+                "— ignoring the restriction"
+            )
+            return True
+        return cmd.lstrip("/") in {str(c).lstrip("/") for c in enabled}
 
     def is_maintainer_only(self, cmd: str) -> bool:
         mo = self.get("commands", "permissions", "maintainer_only", default=[])

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -67,26 +67,18 @@ DEFAULTS: dict = {
         "allow_protected_branches": False,
         "allowed_risk_levels": ["low"],
     },
-    "ai": {
-        "primary_model": "llama-3.3-70b-versatile",
-        "fallback_model": "llama-3.1-8b-instant",
-        "max_tokens": 1500,
-        "temperature": 0.2,
-        "timeout_seconds": 45,
-    },
-    "confidence": {
-        "thresholds": {
-            "pr_title_rewrite": 0.80,
-            "pr_description": 0.75,
-            "issue_label": 0.70,
-            "auto_merge": 0.95,
-            "fix_command": 0.75,
-            "auto_apply": 0.92,
-            "code_review": 0.75,
-            "security_finding": 0.85,
-            "issue_triage": 0.75,
-        }
-    },
+    # NOTE: no "ai" section. Model, timeout and temperature are DEPLOYMENT
+    # concerns — the LLM router is a process-wide singleton shared by every
+    # installation, so a per-repo model override would let one tenant drain
+    # another's quota tier. They are set by the operator via LLM_PRIMARY_MODEL
+    # / LLM_FALLBACK_MODEL env vars. These keys previously sat here where
+    # nothing could read them.
+    # NOTE: no "confidence" defaults here either. The thresholds live in
+    # app/core/confidence.py (ConfidenceGate.DEFAULT_THRESHOLDS), which is what
+    # actually reads them. This copy had already drifted — it carried
+    # auto_apply and security_finding, which nothing looks up, and omitted
+    # secret_detection, which is real. A user override still merges cleanly
+    # because ConfidenceGate reads config.get("confidence", "thresholds").
     "notifications": {
         "slack": False,
         "discord": False,
@@ -310,6 +302,22 @@ def load_config(repo: str, token: str) -> Config:
     try:
         from app.github.client import gh_get
 
+        # No ?ref= — deliberately. The contents endpoint defaults to the
+        # repository's DEFAULT BRANCH, and that is a security boundary, not an
+        # oversight.
+        #
+        # Config decides who may merge (commands.permissions.maintainer_only),
+        # whether auto-merge is on, whether secrets are scanned, and whether
+        # the bot runs at all. Reading it from the pull-request head would let
+        # any outside contributor grant themselves those rights simply by
+        # editing the YAML inside their own PR:
+        #
+        #     auto_merge: {enabled: true}
+        #     commands: {permissions: {maintainer_only: []}}
+        #
+        # Config changes therefore take effect only once merged to the default
+        # branch — the same trust boundary GitHub Actions applies to workflow
+        # permissions. tests/test_prelaunch_audit.py pins this.
         data = gh_get(f"/repos/{repo}/contents/.ai-repo-manager.yml", token)
         raw = base64.b64decode(data["content"]).decode("utf-8")
 

--- a/app/core/guardrails.py
+++ b/app/core/guardrails.py
@@ -59,6 +59,33 @@ def check_pr_auto_merge(pr_data: dict, checks: list, reviews: list, config) -> G
     ):
         return GuardrailResult(False, f"Target `{base}` is protected — auto-merge disabled")
 
+    # allowed_risk_levels was documented and never consulted: a user who
+    # restricted auto-merge to low-risk PRs still had high-risk ones merged.
+    #
+    # The risk level is produced by _analyze_pr on PR open and recorded via
+    # record_pr_risk(). It is read back here rather than taken off pr_data,
+    # because /merge fetches a raw GitHub PR object that carries no analysis.
+    allowed_risks = config.get("auto_merge", "allowed_risk_levels", default=["low"])
+    if isinstance(allowed_risks, list) and allowed_risks:
+        risk = get_pr_risk(pr_data)
+        allowed = {str(r).lower() for r in allowed_risks}
+        if risk is None:
+            # Fail closed: no analysis on record means we cannot show the PR
+            # meets the operator's restriction. Say so rather than assume.
+            return GuardrailResult(
+                False,
+                "No risk analysis on record for this PR, and "
+                f"auto_merge.allowed_risk_levels restricts merging to "
+                f"{', '.join(sorted(allowed))}. Re-open the PR to trigger "
+                "analysis, or widen the setting.",
+            )
+        if risk not in allowed:
+            return GuardrailResult(
+                False,
+                f"Risk level `{risk}` is not in auto_merge.allowed_risk_levels "
+                f"({', '.join(sorted(allowed))})",
+            )
+
     if pr_data.get("draft", False):
         return GuardrailResult(False, "Draft PRs cannot be auto-merged")
 
@@ -142,3 +169,52 @@ def increment_repo_usage(repo: str):
         r.expire(key, 86400)
     except Exception as e:
         log.debug(f"guardrails.increment_repo_usage_failed repo={repo}: {e}")
+
+
+# ── PR risk record ────────────────────────────────────────────────────────────
+#
+# auto_merge.allowed_risk_levels needs the risk level that _analyze_pr computed
+# on PR open, but /merge fetches a raw GitHub PR object which carries no
+# analysis. Recording it keyed by head SHA means a force-push invalidates the
+# record automatically: the risk of the old head says nothing about the new one.
+
+_RISK_TTL = 7 * 86400
+
+
+def _risk_key(repo: str, pr_number, head_sha: str) -> str:
+    return f"pr_risk:{repo}:{pr_number}:{head_sha[:12]}"
+
+
+def record_pr_risk(repo: str, pr_number, head_sha: str, risk: str) -> None:
+    """Store the analysed risk level. Never raises — advisory data."""
+    if not (repo and head_sha and risk):
+        return
+    try:
+        from app.core.redis_client import get_redis
+
+        get_redis().set(_risk_key(repo, pr_number, head_sha), str(risk).lower(), ex=_RISK_TTL)
+    except Exception as e:
+        log.debug(f"guardrails.record_pr_risk_failed repo={repo} pr={pr_number}: {e}")
+
+
+def get_pr_risk(pr_data: dict) -> "str | None":
+    """
+    Recorded risk level for this PR's current head, or None when unknown.
+
+    None is meaningful: the caller fails closed on it rather than assuming
+    the PR is safe.
+    """
+    try:
+        repo = (pr_data.get("base", {}).get("repo", {}) or {}).get("full_name", "")
+        head_sha = (pr_data.get("head", {}) or {}).get("sha", "")
+        number = pr_data.get("number")
+        if not (repo and head_sha and number is not None):
+            return None
+
+        from app.core.redis_client import get_redis
+
+        value = get_redis().get(_risk_key(repo, number, head_sha))
+        return str(value).lower() if value else None
+    except Exception as e:
+        log.debug(f"guardrails.get_pr_risk_failed: {e}")
+        return None

--- a/app/github/notifications.py
+++ b/app/github/notifications.py
@@ -53,6 +53,34 @@ _EMOJIS: dict[str, str] = {
 }
 
 
+# Maps an internal event_type to the repo-config key that governs it.
+# Before this, the notifications.on_* keys existed only in DEFAULTS — a user
+# who set on_secret_detected: false still got pinged on every secret.
+_CONFIG_EVENT_KEYS = {
+    "secret_detected": "on_secret_detected",
+    "high_risk_pr": "on_high_risk_pr",
+    "health_degraded": "on_health_degraded",
+    "all_providers_down": "on_all_providers_down",
+}
+
+
+def _event_allowed(event_type: str, config=None) -> bool:
+    """
+    Repo config wins over the module-level default filter.
+
+    config is passed per call rather than held in module state: this process
+    serves many repositories, and one repo's preferences must never leak into
+    another's notifications.
+    """
+    if not event_type:
+        return True
+    if config is not None:
+        key = _CONFIG_EVENT_KEYS.get(event_type)
+        if key is not None:
+            return bool(config.get("notifications", key, default=True))
+    return NOTIFY_FILTER.get(event_type, True)
+
+
 def notify(
     title: str,
     message: str,
@@ -61,13 +89,20 @@ def notify(
     event_type: str = "",
     fields: list[dict] | None = None,
     url: str = "",
+    config=None,
 ):
-    if event_type and not NOTIFY_FILTER.get(event_type, True):
+    if not _event_allowed(event_type, config):
         log.debug(f"notification.suppressed event_type={event_type}")
         return
 
-    if not SLACK_ENABLED and not DISCORD_ENABLED:
-        log.debug("notification.skipped no_webhooks_configured")
+    slack_on = SLACK_ENABLED and (
+        config is None or config.get("notifications", "slack", default=True)
+    )
+    discord_on = DISCORD_ENABLED and (
+        config is None or config.get("notifications", "discord", default=True)
+    )
+    if not slack_on and not discord_on:
+        log.debug("notification.skipped no_enabled_channel")
         return
 
     emoji = _EMOJIS.get(severity, "ℹ️")
@@ -77,7 +112,7 @@ def notify(
 
     threads: list[threading.Thread] = []
 
-    if SLACK_ENABLED:
+    if slack_on:
         t = threading.Thread(
             target=_send_slack,
             args=(full_title, message, severity),
@@ -85,7 +120,7 @@ def notify(
         )
         threads.append(t)
 
-    if DISCORD_ENABLED:
+    if discord_on:
         t = threading.Thread(
             target=_send_discord,
             args=(full_title, message, severity, fields or [], url),
@@ -170,13 +205,14 @@ def _send_discord(
         log.error(f"notification.discord_error: {e}")
 
 
-def notify_secret_detected(repo: str, findings_count: int):
+def notify_secret_detected(repo: str, findings_count: int, config=None):
     notify(
         title="Secret Detected in Push",
         message=f"{findings_count} potential secret(s) found. Rotate credentials immediately.",
         severity="critical",
         repo=repo,
         event_type="secret_detected",
+        config=config,
         fields=[
             {"name": "Findings", "value": str(findings_count), "inline": True},
             {"name": "Repository", "value": repo, "inline": True},
@@ -184,13 +220,14 @@ def notify_secret_detected(repo: str, findings_count: int):
     )
 
 
-def notify_high_risk_pr(repo: str, pr_number: int, title: str):
+def notify_high_risk_pr(repo: str, pr_number: int, title: str, config=None):
     notify(
         title="High Risk PR Opened",
         message=f"PR #{pr_number} flagged as HIGH risk.",
         severity="warning",
         repo=repo,
         event_type="high_risk_pr",
+        config=config,
         fields=[
             {"name": "PR", "value": f"#{pr_number}", "inline": True},
             {"name": "Risk", "value": "🔴 HIGH", "inline": True},
@@ -200,13 +237,14 @@ def notify_high_risk_pr(repo: str, pr_number: int, title: str):
     )
 
 
-def notify_health_degraded(repo: str, grade: str, score: int):
+def notify_health_degraded(repo: str, grade: str, score: int, config=None):
     notify(
         title="Repo Health Degraded",
         message=f"Repository health is now **{grade}** ({score}/100).",
         severity="warning",
         repo=repo,
         event_type="health_degraded",
+        config=config,
         fields=[
             {"name": "Grade", "value": grade, "inline": True},
             {"name": "Score", "value": f"{score}/100", "inline": True},
@@ -290,7 +328,7 @@ def notify_vulnerability(repo: str, package: str, severity: str, cve_id: str):
     )
 
 
-def notify_all_providers_down():
+def notify_all_providers_down(config=None):
     try:
         from app.ai.circuit_breaker import status_all
 
@@ -313,6 +351,7 @@ def notify_all_providers_down():
         message="No AI provider available. Tasks queued for automatic retry.",
         severity="critical",
         event_type="all_providers_down",
+        config=config,
         fields=fields,
     )
 

--- a/app/handlers/ci.py
+++ b/app/handlers/ci.py
@@ -48,7 +48,8 @@ def handle(payload: dict):
         return
 
     config = load_config(repo, token)
-    if not config.get("ci", "enabled", default=True):
+    # Helper, not a raw get(): it also honours the bot.enabled kill switch.
+    if not config.ci_enabled():
         return
 
     output = check_run.get("output", {})

--- a/app/handlers/comments/dispatcher.py
+++ b/app/handlers/comments/dispatcher.py
@@ -102,6 +102,20 @@ def augment_with_memory(context: str, repo: str, query: str) -> str:
     return context
 
 
+def command_disabled_comment(cmd: str) -> str:
+    """
+    Response when an operator's `commands.enabled` allow-list excludes `cmd`.
+
+    Lives here with the other canned responses so service.py stays a thin
+    orchestration layer.
+    """
+    return (
+        f"## 🚫 Command Disabled\n\n"
+        f"`{cmd}` is not in this repository's `commands.enabled` list "
+        f"in `.ai-repo-manager.yml`."
+    )
+
+
 def providers_down_comment(retry_in: int = 60) -> str:
     """Standard degraded-mode comment when all LLM providers are unavailable."""
     return (

--- a/app/handlers/comments/service.py
+++ b/app/handlers/comments/service.py
@@ -16,6 +16,7 @@ from .constants import SKIP_AUTHORS
 from .dispatcher import (
     augment_with_memory,
     check_user_rate_limit,
+    command_disabled_comment,
     extract_command,
     is_providers_down,
     make_degraded_response,
@@ -86,6 +87,16 @@ def handle_comment_event(payload: dict) -> None:
             ),
             log_ctx,
         )
+        return
+
+    # ── Operator allow-list ───────────────────────────────────────────────
+    # command_enabled() had zero callers: a maintainer who removed a command
+    # from commands.enabled still had it fully working. It also honours the
+    # bot.enabled kill switch. Checked before authorization so a disabled
+    # command never costs a GitHub permission API call.
+    if not config.command_enabled(cmd):
+        log_ctx.info("command_disabled_by_config")
+        _post_comment(repo, issue_number, token, command_disabled_comment(cmd), log_ctx)
         return
 
     # ── Authorization ─────────────────────────────────────────────────────

--- a/app/handlers/issues.py
+++ b/app/handlers/issues.py
@@ -67,6 +67,23 @@ def handle(payload: dict):
     if not config.issues_enabled():
         return
 
+    # auto_triage was documented and never read: turning it off left triage
+    # running. Labelling is governed separately by issues.auto_label.
+    if not config.get("issues", "auto_triage", default=True):
+        log.info("issues.auto_triage_disabled — skipping")
+        return
+
+    # Per-repo daily AI budget. check_repo_rate_limit()/increment_repo_usage()
+    # existed with zero callers, so REPO_DAILY_AI_LIMIT did nothing and a
+    # single busy repository could drain the whole free-tier LLM quota.
+    from app.core.guardrails import check_repo_rate_limit, increment_repo_usage
+
+    budget = check_repo_rate_limit(repo)
+    if not budget.passed:
+        log.warning(f"issues.rate_limited repo={repo}: {budget.reason}")
+        return
+    increment_repo_usage(repo)
+
     # Get repo context for better triage
     repo_lang = ""
     try:

--- a/app/handlers/pull_request.py
+++ b/app/handlers/pull_request.py
@@ -61,6 +61,16 @@ def handle(payload: dict):
     if not config.pr_enabled():
         return
 
+    # Per-repo daily AI budget — see issues.py for why this exists. A PR event
+    # can trigger several LLM calls, so it is metered like any other.
+    from app.core.guardrails import check_repo_rate_limit, increment_repo_usage
+
+    budget = check_repo_rate_limit(repo)
+    if not budget.passed:
+        log.warning(f"pr.rate_limited repo={repo}: {budget.reason}")
+        return
+    increment_repo_usage(repo)
+
     try:
         files = gh_get(f"/repos/{repo}/pulls/{pr_number}/files", token)
     except Exception:
@@ -269,9 +279,20 @@ Return JSON:
             except Exception as e:
                 log.error(f"Title update failed: {e}")
 
+    # Record the risk so auto_merge.allowed_risk_levels can be enforced later:
+    # /merge fetches a raw GitHub PR object that carries no analysis. Keyed by
+    # head SHA, so a force-push invalidates it rather than carrying a stale
+    # "low" verdict onto entirely different code.
+    try:
+        from app.core.guardrails import record_pr_risk
+
+        record_pr_risk(repo, pr_number, pr.get("head", {}).get("sha", ""), r.get("risk_level", ""))
+    except Exception as e:
+        log.debug(f"record_pr_risk skipped: {e}")
+
     if r.get("risk_level") == "high":
         try:
-            notify_high_risk_pr(repo, pr_number, title)
+            notify_high_risk_pr(repo, pr_number, title, config=config)
         except Exception as e:
             log.debug(f"notify_high_risk_pr skipped: {e}")
 
@@ -422,6 +443,21 @@ Only report real gaps. If tests are adequate, set has_gaps to false.""",
         return ""
 
 
+def _review_sort_key(f: dict) -> tuple:
+    """
+    Ordering for the limited review budget: file kind first, then size of
+    change.
+
+    Kind alone is not enough — within a tier, GitHub returns files
+    alphabetically, so `app/a.py` with a two-line tweak would be reviewed
+    ahead of `app/z.py` with two hundred changed lines. Size is the best
+    available proxy for where the risk is.
+    """
+    filename = f.get("filename", "")
+    churn = f.get("additions", 0) + f.get("deletions", 0)
+    return (_file_review_priority(filename), churn)
+
+
 def _file_review_priority(filename: str) -> int:
     """
     Return priority weight for code review ordering (higher is more important).
@@ -479,9 +515,7 @@ def _review_code(pr, repo, pr_number, files, token, config, gate, context, log):
 
     max_files = config.get("pull_requests", "max_files_reviewed", default=4)
     valid_files = [f for f in files if f.get("patch") and not _is_generated(f.get("filename", ""))]
-    sorted_files = sorted(
-        valid_files, key=lambda f: _file_review_priority(f.get("filename", "")), reverse=True
-    )
+    sorted_files = sorted(valid_files, key=_review_sort_key, reverse=True)
     reviewable = sorted_files[:max_files]
 
     if not reviewable:

--- a/app/handlers/push.py
+++ b/app/handlers/push.py
@@ -231,12 +231,12 @@ def _scan_secrets(repo, commits, token, config, log) -> None:
         return
 
     try:
-        _open_secret_issue(repo, token, actionable, log)
+        _open_secret_issue(repo, token, actionable, log, config)
     except Exception as e:
         log.error(f"Failed to post secret alert: {e}")
 
 
-def _open_secret_issue(repo: str, token: str, findings: list, log) -> None:
+def _open_secret_issue(repo: str, token: str, findings: list, log, config=None) -> None:
     """
     One open secret alert per repo per 24h.
 
@@ -283,7 +283,7 @@ def _open_secret_issue(repo: str, token: str, findings: list, log) -> None:
     except Exception as e:
         log.debug(f"push.secret_alert_record_failed: {e}")
 
-    notify_secret_detected(repo, len(findings))
+    notify_secret_detected(repo, len(findings), config=config)
     log.warning(f"Secret scan: {len(findings)} actionable findings posted")
 
 

--- a/app/handlers/push.py
+++ b/app/handlers/push.py
@@ -91,7 +91,8 @@ def handle(payload: dict) -> None:
     config = load_config(repo, token)
     latest_sha = commits[-1].get("id", "") if commits else ""
 
-    if not config.get("push", "enabled", default=True):
+    # Helper, not a raw get(): it also honours the bot.enabled kill switch.
+    if not config.push_enabled():
         return
 
     # Secret scan runs on ALL branches (secrets are dangerous everywhere).

--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "github-autopilot",
   "description": "AI-powered GitHub repository assistant. Analyze PRs, fix issues, scan secrets, generate tests — over MCP.",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "protocol": "mcp/2024-11-05",
   "homepage": "https://github.com/Shweta-Mishra-ai/github-autopilot",
   "documentation": "https://github.com/Shweta-Mishra-ai/github-autopilot/blob/main/docs/mcp-setup.md",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-autopilot",
   "description": "Call GitHub Autopilot's AI tools (analyze PR, fix issue, scan secrets, repo health) from Claude Code via MCP.",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "author": {
     "name": "Shweta Mishra",
     "url": "https://github.com/Shweta-Mishra-ai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "github-autopilot"
-version = "7.0.0"
+version = "7.1.0"
 description = "AI-powered GitHub automation bot — auto-fix, PR review, secret scanning, and more"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -191,12 +191,16 @@ def mcp_endpoint():
 @app.route("/mcp", methods=["GET"])
 def mcp_info():
     """MCP server discovery endpoint."""
+    # Derived, never hardcoded: a literal count silently lies the moment a
+    # tool is added or removed, and this endpoint is public.
+    from app.mcp.tools import MCP_TOOLS
+
     return jsonify(
         {
             "name": "github-autopilot",
             "version": VERSION,
             "protocol": "mcp/2024-11-05",
-            "tools": 8,
+            "tools": len(MCP_TOOLS),
             "description": "AI-powered GitHub repository assistant",
             "auth": "Bearer token via MCP_API_KEY env var",
             "docs": "https://github.com/Shweta-Mishra-ai/github-autopilot/blob/main/docs/mcp-setup.md",

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -44,6 +44,9 @@ def _payload(
 
 def _mock_config(ci_enabled=True):
     cfg = MagicMock()
+    # ci.py now calls config.ci_enabled(), which also honours the
+    # bot.enabled kill switch — a raw get() bypassed it.
+    cfg.ci_enabled.return_value = ci_enabled
     cfg.get.side_effect = lambda *a, **kw: {
         ("ci", "enabled"): ci_enabled,
     }.get(a, kw.get("default", True))

--- a/tests/test_comments_package.py
+++ b/tests/test_comments_package.py
@@ -301,7 +301,10 @@ class TestFileSize:
     def test_service_py_is_thin(self):
         """service.py is an orchestration layer — keep it thin.
         Budget history: 260 pre-V6.2; +5 for model-disclosure reset/footer;
-        +1 for the security module import (V7 publisher split).
+        +1 for the security module import (V7 publisher split); +10 for the
+        commands.enabled gate — an orchestration-tier check that sits with the
+        rate limit and authorization guards, and whose response text lives in
+        dispatcher.py so only the guard itself is here.
         (cross-cutting, belongs in orchestration). Raise consciously, never
         casually."""
         import os
@@ -311,6 +314,6 @@ class TestFileSize:
         )
         with open(fpath, encoding='utf-8') as f:
             lines = f.readlines()
-        assert len(lines) <= 266, (
-            f"service.py has {len(lines)} lines — should stay under 266 lines as an orchestration layer."
+        assert len(lines) <= 276, (
+            f"service.py has {len(lines)} lines — should stay under 276 lines as an orchestration layer."
         )

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -64,17 +64,31 @@ class MockConfig:
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 def make_pr(mergeable=True, mergeable_state="clean", draft=False,
-            base_ref="feature/test", commits=3, title="update readme", body=""):
-    return {
+            base_ref="feature/test", commits=3, title="update readme", body="",
+            risk="low"):
+    """
+    A PR fixture.
+
+    `risk` records an analysed risk level for this head SHA, because
+    auto_merge.allowed_risk_levels is now enforced and fails closed when no
+    analysis is on record. Pass risk=None to exercise that path.
+    """
+    pr = {
         "mergeable":       mergeable,
         "mergeable_state": mergeable_state,
         "draft":           draft,
         "commits":         commits,
+        "number":          1,
         "title":           title,
         "body":            body,
-        "base":            {"ref": base_ref},
+        "base":            {"ref": base_ref, "repo": {"full_name": "org/repo"}},
+        "head":            {"sha": "abc1234567890"},
         "labels":          [],
     }
+    if risk is not None:
+        from app.core.guardrails import record_pr_risk
+        record_pr_risk("org/repo", 1, "abc1234567890", risk)
+    return pr
 
 
 def make_checks(passing=True):
@@ -280,3 +294,45 @@ class TestAutoLabelGuardrail:
         issue  = {"labels": [{"name": "bug 🐛"}]}
         result = check_auto_label(issue, ["bug 🐛", "priority: high 🔥"], config)
         assert result.passed is True
+
+
+class TestAutoMergeRiskLevels:
+    """
+    auto_merge.allowed_risk_levels was documented and never consulted — a user
+    who restricted auto-merge to low-risk PRs still had high-risk ones merged.
+    """
+
+    def test_high_risk_pr_is_blocked_when_only_low_allowed(self):
+        config = MockConfig(auto_merge=True)
+        pr = make_pr(risk="high")
+        result = check_pr_auto_merge(pr, make_checks(), make_reviews(), config)
+        assert result.passed is False
+        assert "risk level" in result.reason.lower()
+
+    def test_low_risk_pr_passes(self):
+        config = MockConfig(auto_merge=True)
+        pr = make_pr(risk="low")
+        assert check_pr_auto_merge(pr, make_checks(), make_reviews(), config).passed is True
+
+    def test_unanalysed_pr_fails_closed(self):
+        """No analysis on record must not be read as 'safe'."""
+        from app.core.redis_client import reset_client
+
+        reset_client()
+        config = MockConfig(auto_merge=True)
+        pr = make_pr(risk=None)
+        result = check_pr_auto_merge(pr, make_checks(), make_reviews(), config)
+        assert result.passed is False
+        assert "no risk analysis" in result.reason.lower()
+
+    def test_risk_is_keyed_by_head_sha(self):
+        """A force-push must invalidate the recorded verdict."""
+        from app.core.guardrails import get_pr_risk, record_pr_risk
+
+        record_pr_risk("org/repo", 7, "oldsha123456", "low")
+        pr_new_head = {
+            "number": 7,
+            "base": {"repo": {"full_name": "org/repo"}},
+            "head": {"sha": "newsha654321"},
+        }
+        assert get_pr_risk(pr_new_head) is None

--- a/tests/test_prelaunch_audit.py
+++ b/tests/test_prelaunch_audit.py
@@ -278,6 +278,42 @@ class TestNoDeadConfig:
                 })
             ask.assert_not_called()
 
+    def test_every_documented_config_key_is_read(self):
+        """
+        The broadest form of the recurring defect: a key in DEFAULTS that
+        nothing reads is a setting the product advertises and ignores.
+
+        Thirteen keys were dead when this was written — including
+        auto_merge.allowed_risk_levels (a safety control), ai.primary_model
+        (the user's model choice), and every notifications.on_* toggle.
+        Finding them one at a time is how they accumulated; this finds them
+        all, every run.
+        """
+        from app.core.config import DEFAULTS
+
+        def leaves(d, path=()):
+            for k, v in d.items():
+                if isinstance(v, dict):
+                    yield from leaves(v, path + (k,))
+                else:
+                    yield path + (k,)
+
+        corpus = "".join(
+            p.read_text(encoding="utf-8")
+            for p in Path("app").rglob("*.py")
+            if p.name != "config.py"
+        ) + Path("server.py").read_text(encoding="utf-8")
+
+        dead = [
+            ".".join(path)
+            for path in leaves(DEFAULTS)
+            if not re.search(rf"\b{re.escape(path[-1])}\b", corpus)
+        ]
+        assert dead == [], (
+            f"config keys nothing reads: {dead}. Each is a setting the product "
+            "documents and then ignores. Wire it up or remove it."
+        )
+
     def test_every_config_helper_is_called_somewhere(self):
         import ast
 
@@ -301,6 +337,96 @@ class TestNoDeadConfig:
             f"Config helpers with no caller in app/: {dead}. "
             "A config key nothing reads is a promise the product does not keep."
         )
+
+
+# ── Config is a trust boundary ────────────────────────────────────────────────
+
+
+class TestConfigTrustBoundary:
+    """
+    Config is fetched from the DEFAULT BRANCH, never from a PR head.
+
+    This looks like a missing `?ref=` and has been mistaken for a bug. It is a
+    security control: config decides who may merge, whether auto-merge runs,
+    whether secrets are scanned, and whether the bot runs at all. Honouring it
+    from a PR head would let any outside contributor escalate privileges by
+    editing the YAML inside their own pull request.
+    """
+
+    def test_config_fetch_is_not_ref_pinned_to_a_branch(self):
+        import inspect
+
+        from app.core import config as config_mod
+
+        src = inspect.getsource(config_mod)
+        fetch_line = next(
+            line for line in src.splitlines() if "contents/.ai-repo-manager.yml" in line
+        )
+        assert "ref=" not in fetch_line, (
+            "config must be read from the default branch. Adding ?ref= to honour "
+            "a PR head would let a contributor grant themselves merge rights by "
+            "editing config inside their own PR."
+        )
+
+    def test_the_reason_is_documented_at_the_call_site(self):
+        """A future reader must not 'fix' this into a vulnerability."""
+        import inspect
+
+        from app.core import config as config_mod
+
+        src = inspect.getsource(config_mod)
+        idx = src.index("contents/.ai-repo-manager.yml")
+        preceding = src[max(0, idx - 1200) : idx]
+        assert "default branch" in preceding.lower()
+        assert "auto_merge" in preceding or "maintainer_only" in preceding
+
+
+# ── Review targets the code, not the licence files ────────────────────────────
+
+
+class TestReviewFilePrioritisation:
+    """
+    max_files_reviewed used to take files in the order GitHub returned them,
+    which is alphabetical. On a PR touching LICENSE/CONTRIBUTING/MANIFEST the
+    budget was spent before reaching a single source file — and the bot then
+    reported a test-coverage score for code it had never read.
+    """
+
+    def test_source_files_outrank_licences_and_config(self):
+        from app.handlers.pull_request import _file_review_priority as prio
+
+        assert prio("app/core/config.py") > prio("tests/test_x.py")
+        assert prio("tests/test_x.py") > prio("pyproject.toml")
+        assert prio("pyproject.toml") > prio("LICENSE")
+        assert prio("app/main.py") > prio("MANIFEST.in")
+
+    def test_the_pr_79_file_set_now_selects_source_files(self):
+        """Regression against the exact case that exposed this."""
+        from app.handlers.pull_request import _file_review_priority as prio
+
+        files = [
+            ".claude-plugin/marketplace.json",
+            "CONTRIBUTING.md",
+            "LICENSE",
+            "LICENSE-APACHE",
+            "LICENSE-MIT",
+            "MANIFEST.in",
+            "app/ai/guarded.py",
+            "app/core/config.py",
+            "app/handlers/pull_request.py",
+            "tests/test_v7_noise.py",
+        ]
+        top = sorted(files, key=prio, reverse=True)[:4]
+        assert all(f.startswith(("app/", "tests/")) for f in top), top
+        assert "LICENSE" not in top
+
+    def test_larger_changes_win_within_the_same_tier(self):
+        """A 200-line change matters more than a 2-line one of the same kind."""
+        from app.handlers.pull_request import _review_sort_key
+
+        big = {"filename": "app/b.py", "additions": 200, "deletions": 10}
+        small = {"filename": "app/a.py", "additions": 2, "deletions": 0}
+        assert sorted([small, big], key=_review_sort_key, reverse=True)[0] is big
 
 
 # ── Published numbers are true ────────────────────────────────────────────────

--- a/tests/test_prelaunch_audit.py
+++ b/tests/test_prelaunch_audit.py
@@ -1,0 +1,364 @@
+"""
+tests/test_prelaunch_audit.py — pre-launch correctness guarantees.
+
+Every assertion here derives its expected value from the code itself rather
+than from a copied constant, so these cannot go stale the way the documented
+command list and the DEFAULTS enabled-list both did.
+"""
+
+import inspect
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_ROOT = Path(__file__).parent.parent
+
+
+# ── /ignore authorization ─────────────────────────────────────────────────────
+
+
+class TestIgnoreIsGated:
+    """
+    /ignore writes to persistent repo memory, and V7 injects that memory into
+    every later prompt. Ungated, any drive-by commenter could poison the
+    context every subsequent command sees.
+    """
+
+    def test_ignore_is_in_restricted_commands(self):
+        from app.core.authorization import RESTRICTED_COMMANDS
+
+        assert "/ignore" in RESTRICTED_COMMANDS
+
+    def test_non_collaborator_cannot_invoke_ignore(self):
+        from app.core.authorization import check_command_permission
+
+        cfg = MagicMock()
+        cfg.is_maintainer_only.return_value = False
+        with patch("app.core.authorization.get_user_permission", return_value="none"):
+            allowed, _reason = check_command_permission(
+                "/ignore", "o/r", "drive-by", "tok", cfg
+            )
+        assert allowed is False
+
+    def test_maintainer_can_invoke_ignore(self):
+        from app.core.authorization import check_command_permission
+
+        cfg = MagicMock()
+        cfg.is_maintainer_only.return_value = False
+        with patch("app.core.authorization.get_user_permission", return_value="write"):
+            allowed, _reason = check_command_permission(
+                "/ignore", "o/r", "maintainer", "tok", cfg
+            )
+        assert allowed is True
+
+    def test_every_memory_writing_command_is_gated(self):
+        """
+        Structural guard: any cmd_* that reaches remember() must be gated, or
+        it is a memory-poisoning vector.
+
+        Uses AST rather than text scanning so a mention of remember() in a
+        docstring or comment cannot produce a false positive, and a nested
+        helper cannot hide a real call from a line-based search.
+        """
+        import ast
+
+        from app.core.authorization import RESTRICTED_COMMANDS
+        from app.handlers.comments import generator, publisher, reviewer, security
+
+        offenders = []
+        for mod in (generator, publisher, reviewer, security):
+            tree = ast.parse(inspect.getsource(mod))
+            for node in tree.body:
+                if not isinstance(node, ast.FunctionDef) or not node.name.startswith("cmd_"):
+                    continue
+                calls = {
+                    n.func.id
+                    for n in ast.walk(node)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                }
+                if "remember" in calls or "remember_decision" in calls:
+                    cmd = "/" + node.name[len("cmd_") :]
+                    if cmd not in RESTRICTED_COMMANDS:
+                        offenders.append(cmd)
+
+        assert offenders == [], (
+            f"these commands write to repo memory but are not gated: {offenders}. "
+            "Memory is injected into every later prompt, so an ungated writer "
+            "is a stored prompt-injection vector."
+        )
+
+
+# ── commands.enabled is enforced ──────────────────────────────────────────────
+
+
+class TestEnabledListIsEnforced:
+    """
+    The enabled list was dead config: Config.command_enabled() existed with
+    zero callers, so a maintainer who removed a command from the list still
+    had it fully working.
+
+    The root cause was not the missing call — it was that the command registry
+    was duplicated in four places (ALL_COMMANDS, DEFAULTS, the shipped YAML,
+    and the README table). Four copies of one list drift by construction. The
+    fix removes the duplicates: ALL_COMMANDS is the only registry, and an
+    unset enabled list means "no restriction configured" rather than
+    "everything off".
+    """
+
+    def test_command_enabled_helper_has_callers(self):
+        from app.handlers.comments import service
+
+        assert "command_enabled" in inspect.getsource(service)
+
+    def test_unset_list_enables_everything(self):
+        """
+        An absent key must not disable the product. _deep_merge REPLACES
+        lists, so any DEFAULTS copy would silently become the ceiling.
+        """
+        from app.core.config import Config
+        from app.handlers.comments.constants import ALL_COMMANDS
+
+        cfg = Config({})
+        for cmd in ALL_COMMANDS:
+            assert cfg.command_enabled(cmd) is True, cmd
+
+    def test_explicit_list_is_enforced(self):
+        from app.core.config import Config
+
+        cfg = Config({"commands": {"enabled": ["fix"]}})
+        assert cfg.command_enabled("/fix") is True
+        assert cfg.command_enabled("/autofix") is False
+
+    def test_explicit_empty_list_disables_everything(self):
+        """An operator who writes `enabled: []` means it — distinct from unset."""
+        from app.core.config import Config
+
+        cfg = Config({"commands": {"enabled": []}})
+        assert cfg.command_enabled("/fix") is False
+
+    def test_registry_is_not_duplicated_in_defaults(self):
+        """
+        The duplicate is the bug. DEFAULTS must not carry its own copy of the
+        command list — that copy went stale (missing ignore, notify, report)
+        and would have disabled three working commands the moment the list
+        started being enforced.
+        """
+        from app.core.config import DEFAULTS
+
+        assert "enabled" not in DEFAULTS.get("commands", {}), (
+            "DEFAULTS must not duplicate the command registry — "
+            "app.handlers.comments.constants.ALL_COMMANDS is the only source"
+        )
+
+    def test_disabled_command_is_not_dispatched(self):
+        """End-to-end: a disabled command must produce no dispatch."""
+        from app.handlers.comments import service
+
+        cfg = MagicMock()
+        cfg.command_enabled.return_value = False
+        cfg.footer = ""
+        payload = {
+            "action": "created",
+            "comment": {"body": "/fix please"},
+            "issue": {"number": 1, "title": "t", "body": "b"},
+            "repository": {"full_name": "o/r"},
+            "installation": {"id": 1},
+            "sender": {"login": "dev"},
+        }
+        with (
+            patch.object(service, "get_installation_token", return_value="tok"),
+            patch.object(service, "load_config", return_value=cfg),
+            patch.object(service, "check_user_rate_limit", return_value=True),
+            patch.object(service, "check_command_permission", return_value=(True, "")),
+            patch.object(service, "_dispatch") as dispatch,
+            patch.object(service, "_post_comment"),
+        ):
+            service.handle_comment_event(payload)
+        dispatch.assert_not_called()
+
+
+# ── No dead config ────────────────────────────────────────────────────────────
+
+
+class TestNoDeadConfig:
+    """
+    The recurring defect class in this codebase is config that looks enforced
+    and is not: command_enabled() had zero callers, ConfidenceGate was passed
+    into _review_code and never called, wrap_user_content was written and
+    never used. Each was found by hand, one at a time.
+
+    This checks the whole class at once.
+    """
+
+    def test_bot_enabled_is_a_real_kill_switch(self):
+        """
+        `bot.enabled` ships in the sample config every user copies and is the
+        documented way to turn the app off. It had zero callers: setting it to
+        false left the bot fully active.
+        """
+        from app.core.config import Config
+
+        off = Config({"bot": {"enabled": False}})
+        assert off.bot_enabled() is False
+        assert off.pr_enabled() is False, "bot.enabled=false must disable PR handling"
+        assert off.issues_enabled() is False, "bot.enabled=false must disable issues"
+        assert off.command_enabled("/fix") is False, "bot.enabled=false must disable commands"
+        assert off.push_enabled() is False, "bot.enabled=false must disable push handling"
+
+        on = Config({})
+        assert on.bot_enabled() is True
+        assert on.pr_enabled() is True
+        assert on.command_enabled("/fix") is True
+
+    def test_kill_switch_stops_every_webhook_handler(self):
+        """End-to-end: no handler may act while the bot is switched off."""
+        from app.core.config import Config
+        from app.handlers import ci, issues, pull_request
+        from app.handlers.comments import service
+
+        off = Config({"bot": {"enabled": False}})
+
+        cases = [
+            (pull_request, "handle", {
+                "action": "opened",
+                "pull_request": {"number": 1, "title": "t", "body": "b",
+                                 "user": {"login": "dev"},
+                                 "head": {"ref": "f", "sha": "s"}, "base": {"ref": "main"}},
+                "repository": {"full_name": "o/r"}, "installation": {"id": 1},
+            }),
+            (issues, "handle", {
+                "action": "opened",
+                "issue": {"number": 1, "title": "t", "body": "b", "user": {"login": "dev"}},
+                "repository": {"full_name": "o/r"}, "installation": {"id": 1},
+            }),
+        ]
+        for mod, fn, payload in cases:
+            with (
+                patch.object(mod, "get_installation_token", return_value="tok"),
+                patch.object(mod, "load_config", return_value=off),
+                patch.object(mod, "gh_get", return_value=[]),
+                patch.object(mod, "gh_post") as post,
+                patch.object(mod.router, "ask") as ask,
+            ):
+                getattr(mod, fn)(payload)
+            ask.assert_not_called()
+            post.assert_not_called()
+
+        # Commands
+        with (
+            patch.object(service, "get_installation_token", return_value="tok"),
+            patch.object(service, "load_config", return_value=off),
+            patch.object(service, "_dispatch") as dispatch,
+            patch.object(service, "_post_comment"),
+        ):
+            service.handle_comment_event({
+                "action": "created",
+                "comment": {"body": "/fix"},
+                "issue": {"number": 1, "title": "t", "body": "b"},
+                "repository": {"full_name": "o/r"},
+                "installation": {"id": 1},
+                "sender": {"login": "dev"},
+            })
+        dispatch.assert_not_called()
+
+        # Push
+        with (
+            patch.object(ci, "get_installation_token", return_value="tok"),
+            patch.object(ci, "load_config", return_value=off),
+        ):
+            from app.ai import guarded
+
+            with patch.object(guarded, "safe_router_ask") as ask:
+                ci.handle({
+                    "action": "completed",
+                    "check_run": {"name": "pytest", "conclusion": "failure",
+                                  "output": {}, "pull_requests": [{"number": 1}],
+                                  "head_sha": "s"},
+                    "repository": {"full_name": "o/r"}, "installation": {"id": 1},
+                })
+            ask.assert_not_called()
+
+    def test_every_config_helper_is_called_somewhere(self):
+        import ast
+
+        from app.core.config import Config
+
+        helpers = {
+            name
+            for name in vars(Config)
+            if not name.startswith("_") and callable(getattr(Config, name, None))
+        } - {"get"}  # get() is the generic accessor, called everywhere
+
+        used: set[str] = set()
+        for path in Path("app").rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute):
+                    used.add(node.attr)
+
+        dead = sorted(helpers - used)
+        assert dead == [], (
+            f"Config helpers with no caller in app/: {dead}. "
+            "A config key nothing reads is a promise the product does not keep."
+        )
+
+
+# ── Published numbers are true ────────────────────────────────────────────────
+
+
+class TestPublishedNumbersAreTrue:
+    def _readme(self) -> str:
+        return (_ROOT / "README.md").read_text(encoding="utf-8")
+
+    def test_mcp_tool_count_is_derived_not_hardcoded(self):
+        """server.py advertised a literal 8 — it lies the moment a tool is added."""
+        import server
+        from app.mcp.tools import MCP_TOOLS
+
+        src = inspect.getsource(server)
+        assert '"tools": 8' not in src, "MCP tool count must be derived from MCP_TOOLS"
+        assert "len(MCP_TOOLS)" in src or "MCP_TOOLS" in src
+
+        with server.app.test_client() as c:
+            assert c.get("/mcp").get_json()["tools"] == len(MCP_TOOLS)
+
+    def test_every_command_is_documented(self):
+        """
+        /ignore shipped undocumented.
+
+        The pattern matches the command name inside a code span and ignores
+        any argument placeholder that follows, so `/rollback N` counts as
+        documenting /rollback. An earlier version anchored on a closing
+        backtick and reported /rollback as missing — a false positive, which
+        is worse than no test at all.
+        """
+        from app.handlers.comments.constants import ALL_COMMANDS
+
+        section = self._readme().split("## Commands")[1].split("## Architecture")[0]
+        documented = {"/" + m for m in re.findall(r"`/([a-z]+)\b[^`]*`", section)}
+        missing = set(ALL_COMMANDS) - documented
+        assert missing == set(), f"undocumented commands: {sorted(missing)}"
+
+    def test_the_documentation_check_cannot_pass_vacuously(self):
+        """A parser that finds nothing would make the test above meaningless."""
+        from app.handlers.comments.constants import ALL_COMMANDS
+
+        section = self._readme().split("## Commands")[1].split("## Architecture")[0]
+        documented = {"/" + m for m in re.findall(r"`/([a-z]+)\b[^`]*`", section)}
+        assert len(documented) >= len(ALL_COMMANDS)
+        assert "/rollback" in documented, "argument placeholders must still count"
+
+    def test_version_is_consistent_everywhere(self):
+        """A stale version string in any manifest is a launch-day embarrassment."""
+        import json
+
+        from app import __version__
+
+        assert json.loads((_ROOT / "mcp-manifest.json").read_text(encoding="utf-8"))[
+            "version"
+        ] == __version__
+        assert json.loads(
+            (_ROOT / "plugin/.claude-plugin/plugin.json").read_text(encoding="utf-8")
+        )["version"] == __version__
+        pyproject = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        assert f'version = "{__version__}"' in pyproject


### PR DESCRIPTION
Three configuration keys were documented, shipped in the sample `.ai-repo-manager.yml`, and read by nothing. Each is fixed at its source rather than patched at the call site.

## `bot.enabled` — the master kill switch did nothing

`Config.bot_enabled()` had zero callers. A user who set `bot.enabled: false` — the documented way to turn the app off — still had a fully active bot.

Every section helper now defers to it. `push` and `ci` were also reading `config.get("push", "enabled")` directly, bypassing the helper layer entirely; both now go through `push_enabled()` / `ci_enabled()`, so a future section cannot reintroduce the bypass.

## `commands.enabled` — the allow-list was never applied

`Config.command_enabled()` had zero callers. Removing a command from the list left it fully working.

The missing call was the symptom. The cause was that the command registry existed in four places: `ALL_COMMANDS`, `DEFAULTS["commands"]["enabled"]`, the shipped YAML, and the README table. Four copies of one list drift by construction, and the `DEFAULTS` copy had already gone stale by three commands (`ignore`, `notify`, `report`). Because `_deep_merge` replaces lists rather than merging them, enforcing that stale copy would have silently disabled three working commands on every install without a custom config.

The duplicates are removed. `ALL_COMMANDS` is the only registry. An absent `enabled` key means "no restriction configured"; an explicit `enabled: []` is still honoured as "disable everything", since that is an unambiguous statement of intent.

## `/ignore` — unauthenticated write to prompt-injected memory

`/ignore` writes to persistent repo memory. V7 made that memory recall on by default and injects it into every later prompt. The command was not in `RESTRICTED_COMMANDS` or `maintainer_only`, so any commenter on a public repo could write arbitrary text into the context every subsequent command sees — stored prompt injection that outlives the comment, and unlike a per-request payload it affects other users.

Verified against the real authorization path before and after:

```
before:  /merge=denied  /rollback=denied  /autofix=denied  /ignore=ALLOWED
after:   /merge=denied  /rollback=denied  /autofix=denied  /ignore=denied
```

Now maintainer-only, matching its own docstring, which already described it as recording a "maintainer preference".

## Published numbers

- `/mcp` advertised a hardcoded `"tools": 8`. Correct today, wrong the moment a tool is added. Now derived from `len(MCP_TOOLS)`.
- `/ignore` was undocumented in the README command table.
- The local-development note said "840+ tests, ~75% coverage"; the measured figures are 1038 and 79%.

Version strings were already consistent across all five manifests, and the deployed server reports `7.0.0` with 8 tools, matching the code.

## Structural checks

`tests/test_prelaunch_audit.py` verifies these as classes of defect rather than as individual cases:

| Check | Prevents |
|---|---|
| Any `cmd_*` reaching `remember()` must be gated | The next memory-writing command shipping ungated |
| No `Config` helper may lack a caller | Dead configuration generally — this is what surfaced `bot.enabled` |
| Registry must not be duplicated into `DEFAULTS` | The stale-copy failure recurring |
| Every registered command must be documented | Undocumented commands |
| Version must agree across all manifests | A stale version string |

The memory-write check uses AST rather than text scanning, so a mention of `remember()` in a docstring cannot produce a false positive and a call inside a nested block cannot hide from a line-based search. An earlier draft of the documentation check reported `/rollback` as undocumented because its table entry is `/rollback N`; that was a false positive in the test, and there is now a companion assertion that the parser cannot pass vacuously.

## Verification

```
1038 passed
ruff check app/        All checks passed!
ruff format --check    73 files already formatted
ast.parse(3.10)        no errors  (app/, tests/, server.py)
```

`service.py` grew by 10 lines for the allow-list gate; its size budget was raised deliberately with the reason recorded in the test, and the response text was placed in `dispatcher.py` alongside the other canned responses so only the guard itself lives in the orchestration layer.