### PR TITLE
Remove notification toggles for features that cannot fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ python server.py
 ```
 
 ```bash
-pytest tests/ -v              # 1051 tests, 79% coverage — the CI badge is the live number
+pytest tests/ -v              # 1053 tests, 79% coverage — the CI badge is the live number
 ruff check app/               # lint
 ```
 

--- a/app/ai/guarded.py
+++ b/app/ai/guarded.py
@@ -52,6 +52,32 @@ def safe_router_ask(
         return {}, None
 
 
+# One alert per outage, not one per affected request. A total provider outage
+# affects every command at once, so an un-deduplicated notification would page
+# the operator dozens of times for a single incident — the same noise problem
+# this release exists to fix.
+_PROVIDERS_DOWN_ALERT_TTL = 900  # 15 minutes
+
+
+def _alert_providers_down() -> None:
+    """Notify once per window that every provider is unavailable. Never raises."""
+    try:
+        from app.core.redis_client import get_redis
+
+        if (
+            get_redis().set("alert:providers_down", "1", nx=True, ex=_PROVIDERS_DOWN_ALERT_TTL)
+            is None
+        ):
+            return  # already alerted inside this window
+
+        from app.github.notifications import notify_all_providers_down
+
+        notify_all_providers_down()
+        log.error("guarded.all_providers_down_alert_sent")
+    except Exception as e:
+        log.debug(f"guarded.providers_down_alert_failed: {e}")
+
+
 def guarded_ask(
     system: str,
     user: str,
@@ -72,6 +98,7 @@ def guarded_ask(
     payload, _meta = safe_router_ask(system, user, task=task, max_tokens=max_tokens)
 
     if isinstance(payload, dict) and payload.get("_providers_down"):
+        _alert_providers_down()
         return (
             {
                 "_degraded": True,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -84,7 +84,6 @@ DEFAULTS: dict = {
         "discord": False,
         "on_secret_detected": True,
         "on_high_risk_pr": True,
-        "on_health_degraded": True,
         "on_all_providers_down": True,
     },
     "labels": {

--- a/app/github/notifications.py
+++ b/app/github/notifications.py
@@ -28,9 +28,6 @@ NOTIFY_FILTER: dict[str, bool] = {
     "high_risk_pr": True,
     "pr_opened": True,
     "new_issue": True,
-    "health_degraded": True,
-    "ci_failure": True,
-    "stale_closed": True,
     "all_providers_down": True,
     "vulnerability_low": False,
     "commit_lint": False,
@@ -59,7 +56,6 @@ _EMOJIS: dict[str, str] = {
 _CONFIG_EVENT_KEYS = {
     "secret_detected": "on_secret_detected",
     "high_risk_pr": "on_high_risk_pr",
-    "health_degraded": "on_health_degraded",
     "all_providers_down": "on_all_providers_down",
 }
 
@@ -237,32 +233,6 @@ def notify_high_risk_pr(repo: str, pr_number: int, title: str, config=None):
     )
 
 
-def notify_health_degraded(repo: str, grade: str, score: int, config=None):
-    notify(
-        title="Repo Health Degraded",
-        message=f"Repository health is now **{grade}** ({score}/100).",
-        severity="warning",
-        repo=repo,
-        event_type="health_degraded",
-        config=config,
-        fields=[
-            {"name": "Grade", "value": grade, "inline": True},
-            {"name": "Score", "value": f"{score}/100", "inline": True},
-        ],
-    )
-
-
-def notify_ci_failure(repo: str, branch: str, error: str):
-    notify(
-        title="CI Failure",
-        message=error[:500],
-        severity="warning",
-        repo=repo,
-        event_type="ci_failure",
-        fields=[{"name": "Branch", "value": f"`{branch}`", "inline": True}],
-    )
-
-
 def notify_new_issue(repo: str, issue_number: int, title: str, labels: list):
     # FIXED (E741): Renamed `l` → `lbl`
     label_str = ", ".join(f"`{lbl}`" for lbl in labels[:5]) or "none"
@@ -293,22 +263,6 @@ def notify_pr_opened(repo: str, pr_number: int, title: str, risk: str = "unknown
             {"name": "Risk", "value": f"{risk_emoji} {risk.capitalize()}", "inline": True},
         ],
         url=f"https://github.com/{repo}/pull/{pr_number}",
-    )
-
-
-def notify_stale_closed(repo: str, issue_number: int, title: str, days_inactive: int):
-    notify(
-        title="Stale Issue Auto-Closed",
-        message=f"Issue #{issue_number} closed after {days_inactive} days of inactivity.",
-        severity="info",
-        repo=repo,
-        event_type="stale_closed",
-        fields=[
-            {"name": "Issue", "value": f"#{issue_number}", "inline": True},
-            {"name": "Inactive", "value": f"{days_inactive} days", "inline": True},
-            {"name": "Title", "value": title[:200]},
-        ],
-        url=f"https://github.com/{repo}/issues/{issue_number}",
     )
 
 

--- a/app/handlers/issues.py
+++ b/app/handlers/issues.py
@@ -84,6 +84,20 @@ def handle(payload: dict):
         return
     increment_repo_usage(repo)
 
+    # Archived repositories are read-only by intent. check_archived_repo()
+    # existed with zero callers, so the bot commented, labelled and reviewed
+    # on them regardless.
+    try:
+        from app.core.guardrails import check_archived_repo
+
+        repo_meta = gh_get(f"/repos/{repo}", token)
+        archived = check_archived_repo(repo_meta)
+        if not archived.passed:
+            log.info(f"skip_archived repo={repo}: {archived.reason}")
+            return
+    except Exception as e:
+        log.debug(f"archived_check_skipped repo={repo}: {e}")
+
     # Get repo context for better triage
     repo_lang = ""
     try:

--- a/app/handlers/pull_request.py
+++ b/app/handlers/pull_request.py
@@ -71,6 +71,20 @@ def handle(payload: dict):
         return
     increment_repo_usage(repo)
 
+    # Archived repositories are read-only by intent. check_archived_repo()
+    # existed with zero callers, so the bot commented, labelled and reviewed
+    # on them regardless.
+    try:
+        from app.core.guardrails import check_archived_repo
+
+        repo_meta = gh_get(f"/repos/{repo}", token)
+        archived = check_archived_repo(repo_meta)
+        if not archived.passed:
+            log.info(f"skip_archived repo={repo}: {archived.reason}")
+            return
+    except Exception as e:
+        log.debug(f"archived_check_skipped repo={repo}: {e}")
+
     try:
         files = gh_get(f"/repos/{repo}/pulls/{pr_number}/files", token)
     except Exception:

--- a/tests/test_prelaunch_audit.py
+++ b/tests/test_prelaunch_audit.py
@@ -314,6 +314,63 @@ class TestNoDeadConfig:
             "documents and then ignores. Wire it up or remove it."
         )
 
+    def test_no_config_key_backs_an_unreachable_feature(self):
+        """
+        Stricter than "is the key read". A key can be read by a filter that
+        nothing ever reaches — notifications.on_health_degraded passed the
+        read-check while notify_health_degraded() had no caller, so the
+        notification could never fire under any circumstance.
+
+        For each notification toggle, the function it governs must be
+        reachable from somewhere other than its own definition.
+        """
+        import ast
+
+        from app.github.notifications import _CONFIG_EVENT_KEYS
+
+        called: set[str] = set()
+        for path in list(Path("app").rglob("*.py")) + [Path("server.py")]:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    fn = node.func
+                    if isinstance(fn, ast.Name):
+                        called.add(fn.id)
+                    elif isinstance(fn, ast.Attribute):
+                        called.add(fn.attr)
+
+        unreachable = [
+            f"notify_{event}"
+            for event in _CONFIG_EVENT_KEYS
+            if f"notify_{event}" not in called
+        ]
+        assert unreachable == [], (
+            f"these notifications are configurable but can never fire: {unreachable}. "
+            "A toggle for an unreachable feature is a promise the product cannot keep."
+        )
+
+    def test_archived_repositories_are_not_acted_on(self):
+        """
+        check_archived_repo() had zero callers, so the bot commented on,
+        labelled and reviewed archived repositories — which are read-only by
+        intent.
+        """
+        import ast
+
+        called: set[str] = set()
+        for path in Path("app/handlers").rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    fn = node.func
+                    if isinstance(fn, ast.Name):
+                        called.add(fn.id)
+                    elif isinstance(fn, ast.Attribute):
+                        called.add(fn.attr)
+        assert "check_archived_repo" in called, (
+            "no handler checks whether the repository is archived"
+        )
+
     def test_every_config_helper_is_called_somewhere(self):
         import ast
 


### PR DESCRIPTION
The "every config key is read" check added in v7.1.0 passed for `notifications.on_health_degraded` because the toggle was wired into the notification filter — while `notify_health_degraded()` itself had no caller anywhere in the codebase. The key was read, and the feature could never fire under any circumstance.

That was a false pass in the test, which is worse than having no test: it certified something that was not true.

## The check is now stricter

For each notification toggle, the function it governs must be reachable from somewhere other than its own definition. Applied, it immediately found `notify_all_providers_down` in the same state.

## Removed

`notify_health_degraded`, `notify_ci_failure` and `notify_stale_closed`, together with the `on_health_degraded` config key.

Nothing can trigger any of them. The periodic health monitor was deleted in v6.1.0 and there is no stale-issue sweep, so these were alerts the product advertised and could never send. Removing them is more honest than leaving a toggle for a feature that does not exist.

## Wired instead

`notify_all_providers_down` is genuinely meaningful — a total provider outage is worth telling the operator about — so it is connected rather than deleted.

It fires at most once per 15-minute window. An outage affects every command simultaneously, so an un-deduplicated alert would page the operator dozens of times for a single incident, which is the same noise problem this release line exists to fix.

## Also fixed

`check_archived_repo()` had zero callers. The bot commented, labelled and reviewed on archived repositories, which are read-only by intent. It is now checked in both the pull-request and issue handlers, with a test asserting some handler performs the check.

## Verification

```
1053 passed
ruff check app/        All checks passed!
ruff format --check    clean
```