### PR TITLE
fix: the eval never measured reviews, and the key was in the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Done. ✈️
 | | |
 |---|---|
 | Modules | 91 |
-| Lines of code | 20,183 |
+| Lines of code | 20,289 |
 | Slash commands | 27 |
 | MCP tools | 9 |
 | Internal imports | 276 |

--- a/app/ai/providers/base.py
+++ b/app/ai/providers/base.py
@@ -210,6 +210,12 @@ def client_error_detail(
 
     where = f" Set {model_env} to a model id the provider currently serves." if model_env else ""
 
+    if status == 402 or "insufficient" in code or "credit" in code:
+        return (
+            f"{CONFIG_ERROR_PREFIX} the provider refused the request for `{model}` "
+            f"({status}) because the account is out of credit. Retrying will not "
+            f"help until it is topped up."
+        )
     if status == 404 or "model_not_found" in code or "not found" in code:
         return (
             f"{CONFIG_ERROR_PREFIX} the provider does not serve the model "

--- a/app/ai/providers/base.py
+++ b/app/ai/providers/base.py
@@ -14,6 +14,7 @@ That's it. Zero changes to handlers or commands.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import os
+import re
 import time
 
 
@@ -265,3 +266,27 @@ def _header(response, name: str):
         return response.headers.get(name)
     except Exception:
         return None
+
+
+# ── Never let a credential into an error string ──────────────────────────────
+#
+# A provider that takes its key as a URL query parameter puts that key into
+# every exception `requests` raises, because those messages quote the URL:
+#
+#   HTTPSConnectionPool(host='...'): Max retries exceeded with url:
+#   /v1beta/models/gemini-1.5-flash:generateContent?key=AIzaSy...
+#
+# That string was assigned to LLMResponse.error and logged by the router as
+# `router.primary_failed ... error=...`, so one network blip wrote the API key
+# into the deployment's logs in plaintext. The key is sent as a header now, so
+# nothing should reach here carrying one; this is the net under that, because
+# the cost of it being wrong once is a rotated credential.
+_SECRET_QUERY_PARAMS = ("key", "api_key", "apikey", "access_token", "token")
+_SECRET_QUERY_RE = re.compile(r"(?i)\b(" + "|".join(_SECRET_QUERY_PARAMS) + r")=([^&\s\"'`]+)")
+
+
+def redact_secrets(text: "str | None") -> str:
+    """Replace `key=<value>` style query parameters with `key=REDACTED`."""
+    if not text:
+        return ""
+    return _SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}=REDACTED", str(text))

--- a/app/ai/providers/gemini.py
+++ b/app/ai/providers/gemini.py
@@ -17,6 +17,7 @@ from app.ai.providers.base import (
     LLMProvider,
     LLMResponse,
     client_error_detail,
+    redact_secrets,
     throttle_pause,
 )
 
@@ -92,13 +93,19 @@ class GeminiProvider(LLMProvider):
                 "temperature": temperature,
             },
         }
-        url = f"{_gemini_url(model)}?key={api_key}"
+        # The key goes in a header, not the query string. As `?key=...` it
+        # ended up in every exception message `requests` raises -- those quote
+        # the URL -- and that message was assigned to LLMResponse.error and
+        # logged by the router, so a single connection error wrote the API key
+        # into the deployment's logs in plaintext. The API accepts either.
+        url = _gemini_url(model)
+        headers = {"Content-Type": "application/json", "x-goog-api-key": api_key}
 
         try:
             r = http_requests.post(
                 url,
                 json=body,
-                headers={"Content-Type": "application/json"},
+                headers=headers,
                 timeout=timeout,
             )
 
@@ -114,7 +121,7 @@ class GeminiProvider(LLMProvider):
                     r = http_requests.post(
                         url,
                         json=body,
-                        headers={"Content-Type": "application/json"},
+                        headers=headers,
                         timeout=timeout,
                     )
 
@@ -197,12 +204,16 @@ class GeminiProvider(LLMProvider):
                 error="Request timed out",
             )
         except Exception as e:
-            breaker.record_failure(str(e)[:60])
+            # Redacted rather than trusted: this string is logged and returned,
+            # and a redirect or a future change could put a credential back
+            # into it. Cheap here, a rotated key if it is missing.
+            safe = redact_secrets(str(e))
+            breaker.record_failure(safe[:60])
             return LLMResponse(
                 text="",
                 provider="gemini",
                 model=model,
-                error=str(e)[:200],
+                error=safe[:200],
             )
 
     def _track(self, total_tokens: int):

--- a/app/ai/providers/groq.py
+++ b/app/ai/providers/groq.py
@@ -155,8 +155,7 @@ class GroqProvider(LLMProvider):
                 # is not a failure and must not count toward the breaker.
                 if pause:
                     log.info(
-                        f"groq.throttled model={self._model} "
-                        f"waiting={pause:g}s then retrying once"
+                        f"groq.throttled model={self._model} waiting={pause:g}s then retrying once"
                     )
                     time.sleep(pause)
                     r = http_requests.post(GROQ_URL, headers=headers, json=body, timeout=timeout)

--- a/app/ai/providers/openrouter.py
+++ b/app/ai/providers/openrouter.py
@@ -17,7 +17,13 @@ import time
 import requests as http_requests
 
 from app.ai.circuit_breaker import get_breaker
-from app.ai.providers.base import LLMProvider, LLMResponse
+from app.ai.providers.base import (
+    LLMProvider,
+    LLMResponse,
+    client_error_detail,
+    redact_secrets,
+    throttle_pause,
+)
 
 log = logging.getLogger(__name__)
 
@@ -35,11 +41,83 @@ class OpenRouterProvider(LLMProvider):
 
     def __init__(self, model: str = DEFAULT_MODEL):
         self._model = model
-        self._api_key = OPENROUTER_API_KEY
+
+    @property
+    def api_key(self) -> str:
+        """
+        Read per call, like the other two providers.
+
+        This was captured in __init__ from a module-level constant read at
+        import. The router builds this provider lazily and gates it on a live
+        os.environ read, so a key set after import produced a provider the
+        router believed was configured and that answered `no_api_key` forever.
+        """
+        return os.environ.get("OPENROUTER_API_KEY", "") or OPENROUTER_API_KEY
 
     @property
     def model_name(self) -> str:
         return self._model
+
+    def _post(self, body: dict, timeout: int):
+        """One place that builds the request. Three copies is how a bug hides."""
+        return http_requests.post(
+            OPENROUTER_URL,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "HTTP-Referer": "https://github.com/Shweta-Mishra-ai/github-autopilot",
+                "X-Title": "GitHub Autopilot",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=timeout,
+        )
+
+    def _throttle_or_fault(self, resp, breaker, repost):
+        """
+        (response, stop) — `stop` is a non-None LLMResponse when the call must
+        not continue.
+
+        The third copy of a bug already fixed in the primary and the fallback:
+        every non-2xx went through raise_for_status into one `except`, which
+        recorded a circuit-breaker failure and returned the raw urllib message.
+        So a rejected key, a retired model, an empty account and a throttle
+        were indistinguishable, all four opened the breaker, and none of the
+        first three can recover by waiting.
+
+        This is the last provider the router reaches for. Opening its breaker
+        on a fault that will not heal is what turns one misconfiguration into
+        "all providers down".
+        """
+        status = getattr(resp, "status_code", 0)
+
+        if status == 429:
+            retry_after, pause = throttle_pause(resp, default=30)
+            if pause:
+                log.info(f"openrouter.throttled waiting={pause:g}s then retrying once")
+                time.sleep(pause)
+                resp = repost()
+                status = getattr(resp, "status_code", 0)
+            if status == 429:
+                retry_after, _ = throttle_pause(resp, default=retry_after)
+                breaker.record_failure(f"rate_limit retry_after={retry_after}s")
+                return resp, LLMResponse(
+                    text="",
+                    provider="openrouter",
+                    model=self._model,
+                    error=f"RATE_LIMIT:{retry_after}",
+                )
+
+        if status in (400, 401, 402, 403, 404):
+            detail = client_error_detail(resp, status, self._model, "OPENROUTER_API_KEY")
+            log.error(f"openrouter.configuration_error status={status} model={self._model}")
+            return resp, LLMResponse(
+                text="",
+                provider="openrouter",
+                model=self._model,
+                error=detail,
+            )
+
+        return resp, None
 
     def call_raw(
         self,
@@ -50,17 +128,10 @@ class OpenRouterProvider(LLMProvider):
         timeout: int = 30,
     ) -> str:
         """Raw API call — returns text. Used by LLMProvider.ask() base."""
-        if not self._api_key:
+        if not self.api_key:
             return ""
-        resp = http_requests.post(
-            OPENROUTER_URL,
-            headers={
-                "Authorization": f"Bearer {self._api_key}",
-                "HTTP-Referer": "https://github.com/Shweta-Mishra-ai/github-autopilot",
-                "X-Title": "GitHub Autopilot",
-                "Content-Type": "application/json",
-            },
-            json={
+        resp = self._post(
+            {
                 "model": self._model,
                 "messages": [
                     {"role": "system", "content": system},
@@ -69,7 +140,7 @@ class OpenRouterProvider(LLMProvider):
                 "max_tokens": max_tokens,
                 "temperature": temperature,
             },
-            timeout=timeout,
+            timeout,
         )
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"]["content"]
@@ -88,33 +159,30 @@ class OpenRouterProvider(LLMProvider):
                 text="", provider="openrouter", model=self._model, error="circuit_open"
             )
 
-        if not self._api_key:
+        if not self.api_key:
             return {}, LLMResponse(
                 text="", provider="openrouter", model=self._model, error="no_api_key"
             )
 
+        body = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "response_format": {"type": "json_object"},
+        }
+
         start = time.time()
         try:
-            resp = http_requests.post(
-                OPENROUTER_URL,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "HTTP-Referer": "https://github.com/Shweta-Mishra-ai/github-autopilot",
-                    "X-Title": "GitHub Autopilot",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": self._model,
-                    "messages": [
-                        {"role": "system", "content": system},
-                        {"role": "user", "content": user},
-                    ],
-                    "max_tokens": max_tokens,
-                    "temperature": temperature,
-                    "response_format": {"type": "json_object"},
-                },
-                timeout=timeout,
-            )
+            resp = self._post(body, timeout)
+            resp, stop = self._throttle_or_fault(resp, breaker, lambda: self._post(body, timeout))
+            if stop is not None:
+                stop.latency_ms = int((time.time() - start) * 1000)
+                return {}, stop
+
             resp.raise_for_status()
             data = resp.json()
             raw_text = data["choices"][0]["message"]["content"]
@@ -140,7 +208,7 @@ class OpenRouterProvider(LLMProvider):
 
         except Exception as e:
             latency_ms = int((time.time() - start) * 1000)
-            err = str(e)[:100]
+            err = redact_secrets(str(e))[:100]
             breaker.record_failure(err)
             log.error(f"openrouter.ask failed: {err}")
             return {}, LLMResponse(
@@ -160,32 +228,29 @@ class OpenRouterProvider(LLMProvider):
                 text="", provider="openrouter", model=self._model, error="circuit_open"
             )
 
-        if not self._api_key:
+        if not self.api_key:
             return "", LLMResponse(
                 text="", provider="openrouter", model=self._model, error="no_api_key"
             )
 
+        body = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": 0.3,
+        }
+
         start = time.time()
         try:
-            resp = http_requests.post(
-                OPENROUTER_URL,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "HTTP-Referer": "https://github.com/Shweta-Mishra-ai/github-autopilot",
-                    "X-Title": "GitHub Autopilot",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": self._model,
-                    "messages": [
-                        {"role": "system", "content": system},
-                        {"role": "user", "content": user},
-                    ],
-                    "max_tokens": max_tokens,
-                    "temperature": 0.3,
-                },
-                timeout=timeout,
-            )
+            resp = self._post(body, timeout)
+            resp, stop = self._throttle_or_fault(resp, breaker, lambda: self._post(body, timeout))
+            if stop is not None:
+                stop.latency_ms = int((time.time() - start) * 1000)
+                return "", stop
+
             resp.raise_for_status()
             data = resp.json()
             text = data["choices"][0]["message"]["content"]
@@ -207,7 +272,7 @@ class OpenRouterProvider(LLMProvider):
 
         except Exception as e:
             latency_ms = int((time.time() - start) * 1000)
-            err = str(e)[:100]
+            err = redact_secrets(str(e))[:100]
             breaker.record_failure(err)
             return "", LLMResponse(
                 text="", provider="openrouter", model=self._model, error=err, latency_ms=latency_ms

--- a/docs/diagrams/codegraph.json
+++ b/docs/diagrams/codegraph.json
@@ -126,8 +126,8 @@
       "id": "app.ai.providers.base",
       "path": "app/ai/providers/base.py",
       "layer": "ai",
-      "loc": 268,
-      "functions": 5,
+      "loc": 299,
+      "functions": 6,
       "classes": 2,
       "is_package": false,
       "fan_in": 7,
@@ -146,7 +146,7 @@
       "id": "app.ai.providers.gemini",
       "path": "app/ai/providers/gemini.py",
       "layer": "ai",
-      "loc": 233,
+      "loc": 244,
       "functions": 2,
       "classes": 1,
       "is_package": false,
@@ -165,7 +165,7 @@
       "id": "app.ai.providers.groq",
       "path": "app/ai/providers/groq.py",
       "layer": "ai",
-      "loc": 285,
+      "loc": 284,
       "functions": 1,
       "classes": 1,
       "is_package": false,
@@ -201,7 +201,7 @@
       "id": "app.ai.providers.openrouter",
       "path": "app/ai/providers/openrouter.py",
       "layer": "ai",
-      "loc": 215,
+      "loc": 280,
       "functions": 0,
       "classes": 1,
       "is_package": false,
@@ -2895,7 +2895,7 @@
   "stats": {
     "modules": 91,
     "edges": 276,
-    "total_loc": 20183,
+    "total_loc": 20289,
     "layers": [
       "ai",
       "core",
@@ -2945,15 +2945,15 @@
         "fan_out": 1
       },
       {
-        "id": "app.core.webhook_security",
-        "loc": 474,
-        "fan_in": 4,
+        "id": "app.ai.providers.base",
+        "loc": 299,
+        "fan_in": 7,
         "fan_out": 1
       },
       {
-        "id": "app.ai.providers.base",
-        "loc": 268,
-        "fan_in": 7,
+        "id": "app.core.webhook_security",
+        "loc": 474,
+        "fan_in": 4,
         "fan_out": 1
       },
       {

--- a/evals/run.py
+++ b/evals/run.py
@@ -79,9 +79,7 @@ def check_configured_models(key: str) -> tuple[bool, str]:
 
     wanted = configured_models()
     try:
-        r = requests.get(
-            GROQ_MODELS_URL, headers={"Authorization": f"Bearer {key}"}, timeout=15
-        )
+        r = requests.get(GROQ_MODELS_URL, headers={"Authorization": f"Bearer {key}"}, timeout=15)
     except Exception as exc:
         return True, f"NOTE: could not check model ids ({type(exc).__name__}); running anyway."
 
@@ -185,6 +183,7 @@ def run_fix_cases() -> tuple[list, list]:
     for index, case in enumerate(_load("fix_cases.json")):
         if index:
             _pace()
+
         # Bound explicitly rather than captured: these are called inside the
         # loop today, but a closure over a loop variable silently reads the
         # LAST case the moment anyone defers the call.
@@ -230,9 +229,25 @@ def run_review_cases() -> tuple[list, list]:
         pr = {"head": {"sha": "eval0000"}}
 
         def _run(pr=pr, files=files, cfg=cfg, captured=captured):
+            # _review_code RETURNS the review; its own docstring says "This
+            # function posts nothing itself." The harness captured gh_post and
+            # threw the return value away, so `captured` was always empty and
+            # every review case scored "".
+            #
+            # That is why the review half of this suite has never measured
+            # anything. It was read as a rate limit, then as a quality
+            # regression -- the failure mode this file's own comments warn
+            # about, in the file that warns about it.
             with patch("app.handlers.pull_request.review.gh_post", side_effect=_capture):
-                _review_code(pr, "eval/repo", 1, files, "tok", cfg, MagicMock(), "", MagicMock())
-            return "\n".join(captured)
+                markdown, inline = _review_code(
+                    pr, "eval/repo", 1, files, "tok", cfg, MagicMock(), "", MagicMock()
+                )
+            # Everything the reviewer produced: the body, the line-anchored
+            # comments, and anything the fallback path did post.
+            parts = [markdown]
+            parts += [c.get("body", "") for c in inline or []]
+            parts += captured
+            return "\n".join(p for p in parts if p)
 
         output = _attempt(_run, case, results)
         if output is None:
@@ -346,8 +361,10 @@ def main() -> int:
         return 4
 
     ok = stats["pass_rate"] >= args.min_pass_rate
-    print(f"\n{'PASS' if ok else 'FAIL'}: pass_rate={stats['pass_rate']} "
-          f"(threshold {args.min_pass_rate})")
+    print(
+        f"\n{'PASS' if ok else 'FAIL'}: pass_rate={stats['pass_rate']} "
+        f"(threshold {args.min_pass_rate})"
+    )
     return 0 if ok else 1
 
 

--- a/evals/run.py
+++ b/evals/run.py
@@ -138,6 +138,15 @@ THROTTLE_BACKOFF_SECONDS = float(os.environ.get("EVAL_THROTTLE_BACKOFF_SECONDS",
 # string when the circuit is open or the request was refused, and the router's
 # degraded reply is a short sentence.
 _BLOCKED_OUTPUT_CHARS = 40
+
+# The markers below are only evidence of a degraded reply in a SHORT output.
+# A real review is long, and one that happens to discuss rate limiting or
+# retrying would otherwise be thrown away as "the provider never answered" --
+# scoring nothing and reporting infrastructure, which is the exact mistake
+# this function exists to prevent. None of the current cases trip it; the
+# bound is here so adding a case about retry logic cannot silently blind the
+# suite again.
+_DEGRADED_REPLY_CHARS = 200
 _BLOCKED_MARKERS = (
     "providers down",
     "provider error",
@@ -160,6 +169,10 @@ def looks_blocked(output: str) -> bool:
     text = (output or "").strip()
     if len(text) < _BLOCKED_OUTPUT_CHARS:
         return True
+    if len(text) > _DEGRADED_REPLY_CHARS:
+        # Long enough to be a real review. The router's degraded reply is a
+        # short sentence, so a marker this far in is the reviewer's own words.
+        return False
     lowered = text.lower()
     return any(marker in lowered for marker in _BLOCKED_MARKERS)
 

--- a/evals/run.py
+++ b/evals/run.py
@@ -238,6 +238,10 @@ def run_review_cases() -> tuple[list, list]:
             # anything. It was read as a rate limit, then as a quality
             # regression -- the failure mode this file's own comments warn
             # about, in the file that warns about it.
+            # Cleared per attempt: _attempt retries a case that came back
+            # empty, and a list shared across attempts would score the second
+            # try's review joined to the first try's.
+            captured.clear()
             with patch("app.handlers.pull_request.review.gh_post", side_effect=_capture):
                 markdown, inline = _review_code(
                     pr, "eval/repo", 1, files, "tok", cfg, MagicMock(), "", MagicMock()

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -78,3 +78,154 @@ class TestCaseFiles:
 
         for c in self._cases("review_cases.json"):
             assert commentable_lines(c["patch"]), f"{c['id']}: patch parses to no lines"
+
+
+class TestTheReviewHarnessActuallySeesTheReview:
+    """
+    The review half of this suite measured nothing at all.
+
+    `_review_code` returns (markdown, inline_comments) and its own docstring
+    says "This function posts nothing itself." The harness patched `gh_post`,
+    collected what it caught, and threw the return value away — so the scored
+    output was always the empty string. Five review cases came back empty
+    every night and were read first as a rate limit, then as a quality
+    regression.
+
+    These tests fail if the harness ever goes blind again: they stub the
+    router with a believable answer and assert the harness comes back with the
+    reviewer's own words in it.
+    """
+
+    _ANSWER = {
+        "confidence": 0.9,
+        "files": [],
+    }
+
+    def _stub_router(self, cases):
+        from unittest.mock import MagicMock
+
+        def fake_ask(_self, _system, user, *a, **k):
+            files = [
+                {
+                    "file": c["filename"],
+                    "score": 3,
+                    "summary": f"SQL injection risk in {c['filename']}.",
+                    "issues": [
+                        {
+                            "severity": "critical",
+                            "line": "3",
+                            "issue": "user input is interpolated into the query",
+                            "fix": "use parameterized queries",
+                        }
+                    ],
+                }
+                for c in cases
+                if f"FILE: {c['filename']}" in user
+            ]
+            meta = MagicMock(provider="groq", model="m", total_tokens=10, cost_usd=0.0)
+            return {"files": files, "confidence": 0.9}, meta
+
+        return fake_ask
+
+    def test_review_cases_produce_scorable_output(self, monkeypatch):
+        from unittest.mock import patch
+
+        import app.ai.router as router_mod
+        import evals.run as ev
+
+        monkeypatch.setenv("EVAL_CASE_DELAY_SECONDS", "0")
+        monkeypatch.setattr(ev, "CASE_DELAY_SECONDS", 0.0)
+
+        cases = json.loads(
+            (_ROOT / "evals" / "cases" / "review_cases.json").read_text(encoding="utf-8")
+        )
+        fake = self._stub_router(cases)
+
+        with patch.object(router_mod.LLMRouter, "ask", fake):
+            results, blocked = ev.run_review_cases()
+
+        # The point of the test: with a provider that answered, nothing is
+        # blocked and every case got a real score.
+        assert blocked == [], f"harness saw no output for {blocked}"
+        assert len(results) == len(cases)
+
+    def test_the_reviewers_own_words_reach_the_scorer(self, monkeypatch):
+        """
+        Not just "non-empty" — the text the reviewer produced. An empty string
+        joined with an empty list is also non-empty once you add a separator,
+        so assert on content the stub uniquely produced.
+        """
+        from unittest.mock import MagicMock, patch
+
+        import app.ai.router as router_mod
+        from app.handlers.pull_request import _review_code
+
+        cases = json.loads(
+            (_ROOT / "evals" / "cases" / "review_cases.json").read_text(encoding="utf-8")
+        )
+        case = cases[0]
+        fake = self._stub_router(cases)
+
+        cfg = MagicMock()
+        cfg.get.side_effect = lambda *a, **kw: kw.get("default", True)
+        cfg.footer = ""
+        files = [{"filename": case["filename"], "patch": case["patch"]}]
+
+        with patch.object(router_mod.LLMRouter, "ask", fake):
+            markdown, inline = _review_code(
+                {"head": {"sha": "eval0000"}},
+                "eval/repo",
+                1,
+                files,
+                "tok",
+                cfg,
+                MagicMock(),
+                "",
+                MagicMock(),
+            )
+
+        combined = "\n".join([markdown] + [c.get("body", "") for c in inline or []])
+        assert "parameterized queries" in combined
+        assert case["filename"] in combined
+
+    def test_gh_post_alone_is_empty(self):
+        """
+        The bug, pinned. Capturing only gh_post yields nothing, so a harness
+        built on it can never score a review — regardless of the provider.
+        """
+        from unittest.mock import MagicMock, patch
+
+        import app.ai.router as router_mod
+        from app.handlers.pull_request import _review_code
+
+        cases = json.loads(
+            (_ROOT / "evals" / "cases" / "review_cases.json").read_text(encoding="utf-8")
+        )
+        case = cases[0]
+        fake = self._stub_router(cases)
+
+        cfg = MagicMock()
+        cfg.get.side_effect = lambda *a, **kw: kw.get("default", True)
+        cfg.footer = ""
+        posted = []
+
+        with (
+            patch.object(router_mod.LLMRouter, "ask", fake),
+            patch(
+                "app.handlers.pull_request.review.gh_post",
+                side_effect=lambda *a, **k: posted.append(a) or {"id": 1},
+            ),
+        ):
+            _review_code(
+                {"head": {"sha": "eval0000"}},
+                "eval/repo",
+                1,
+                [{"filename": case["filename"], "patch": case["patch"]}],
+                "tok",
+                cfg,
+                MagicMock(),
+                "",
+                MagicMock(),
+            )
+
+        assert posted == [], "_review_code posts nothing — the harness must read its return value"

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -229,3 +229,45 @@ class TestTheReviewHarnessActuallySeesTheReview:
             )
 
         assert posted == [], "_review_code posts nothing — the harness must read its return value"
+
+
+class TestLooksBlocked:
+    """
+    The blocked check decides whether a case counts as a quality measurement
+    at all, so a false positive here throws away a real review and reports
+    infrastructure — the exact mistake it exists to prevent.
+    """
+
+    def test_empty_and_stub_outputs_are_blocked(self):
+        from evals.run import looks_blocked
+
+        assert looks_blocked("")
+        assert looks_blocked(None)
+        assert looks_blocked("   ")
+        assert looks_blocked("too short")
+
+    def test_the_routers_degraded_reply_is_blocked(self):
+        from evals.run import looks_blocked
+
+        assert looks_blocked("AI providers are temporarily unavailable — please try again shortly.")
+        assert looks_blocked("Provider error: rate limit reached, try again in 60s.")
+
+    def test_a_real_review_that_mentions_rate_limits_is_not_blocked(self):
+        """
+        A long review is a review. Matching a marker anywhere in it would
+        discard a genuine measurement for using an ordinary phrase — and the
+        markers include "rate limit" and "try again", which any review of
+        retry or throttling code will contain.
+        """
+        from evals.run import looks_blocked
+
+        review = (
+            "### `app/api/client.py` — Score: 4/10\n"
+            "This handler retries on failure without honouring the rate limit "
+            "response, so a throttled request will try again immediately and "
+            "make the problem worse. Read Retry-After and sleep for the delay "
+            "the provider asked for before the next attempt. The surrounding "
+            "error handling is otherwise sound and the tests cover the happy path."
+        )
+        assert len(review) > 200
+        assert not looks_blocked(review)

--- a/tests/test_no_credentials_in_errors.py
+++ b/tests/test_no_credentials_in_errors.py
@@ -1,0 +1,126 @@
+"""
+tests/test_no_credentials_in_errors.py
+
+A provider that takes its key as a URL query parameter puts that key into
+every exception `requests` raises, because those messages quote the URL:
+
+    HTTPSConnectionPool(host='generativelanguage.googleapis.com', port=443):
+    Max retries exceeded with url:
+    /v1beta/models/gemini-1.5-flash:generateContent?key=AIzaSy...
+
+Gemini built exactly that URL. The message was assigned to LLMResponse.error
+and logged by the router as `router.primary_failed ... error=...`, so a single
+connection blip wrote the API key into the deployment's logs in plaintext —
+and Render keeps those.
+
+Two independent guards, because the cost of being wrong once is a rotated
+credential: the key travels in a header now, and anything that still reaches
+an error string is redacted.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.ai.providers.base import redact_secrets
+
+SECRET = "AIzaSyD-NotARealKey-ButShapedLikeOne-0123"
+
+
+class TestTheKeyIsNotInTheUrl:
+
+    def test_gemini_sends_the_key_as_a_header(self, monkeypatch):
+        from app.ai.providers import gemini as gem
+
+        monkeypatch.setenv("GEMINI_API_KEY", SECRET)
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {
+            "candidates": [{"content": {"parts": [{"text": "hi"}]}}],
+            "usageMetadata": {},
+        }
+
+        with (
+            patch.object(gem, "get_breaker", return_value=breaker),
+            patch.object(gem.http_requests, "post", return_value=ok) as post,
+        ):
+            gem.GeminiProvider().call_raw("sys", "user", 100, 0.2, 30)
+
+        args, kwargs = post.call_args
+        assert SECRET not in args[0], "the key is back in the URL — every exception will quote it"
+        assert kwargs["headers"]["x-goog-api-key"] == SECRET
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            requests.exceptions.ConnectionError(
+                "HTTPSConnectionPool(host='generativelanguage.googleapis.com', port=443): "
+                "Max retries exceeded with url: /v1beta/models/gemini-1.5-flash:"
+                f"generateContent?key={SECRET} (Caused by NewConnectionError())"
+            ),
+            requests.exceptions.SSLError(
+                f"Failed for url: https://generativelanguage.googleapis.com/x?key={SECRET}"
+            ),
+        ],
+    )
+    def test_a_key_never_reaches_the_error_or_the_breaker(self, exc, monkeypatch):
+        """The net under the header change: a redirect, or a future edit, must
+        not be able to put a credential into a string that gets logged."""
+        from app.ai.providers import gemini as gem
+
+        monkeypatch.setenv("GEMINI_API_KEY", SECRET)
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+
+        with (
+            patch.object(gem, "get_breaker", return_value=breaker),
+            patch.object(gem.http_requests, "post", side_effect=exc),
+        ):
+            result = gem.GeminiProvider().call_raw("sys", "user", 100, 0.2, 30)
+
+        assert SECRET not in (result.error or ""), f"key leaked into error: {result.error!r}"
+        for call in breaker.record_failure.call_args_list:
+            assert SECRET not in str(call), "key leaked into the breaker's failure reason"
+
+    def test_openrouter_errors_are_redacted_too(self, monkeypatch):
+        from app.ai.providers import openrouter as orx
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-secret")
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        exc = requests.exceptions.ConnectionError(f"url: https://openrouter.ai/x?api_key={SECRET}")
+
+        with (
+            patch.object(orx, "get_breaker", return_value=breaker),
+            patch.object(orx.http_requests, "post", side_effect=exc),
+        ):
+            _result, meta = orx.OpenRouterProvider().ask("sys", "user")
+
+        assert SECRET not in (meta.error or "")
+
+
+class TestRedactSecrets:
+
+    @pytest.mark.parametrize(
+        "param", ["key", "api_key", "apikey", "access_token", "token", "API_KEY", "Key"]
+    )
+    def test_every_credential_query_parameter_is_covered(self, param):
+        assert SECRET not in redact_secrets(f"https://x/y?{param}={SECRET}")
+
+    def test_it_stops_at_the_parameter_boundary(self):
+        """Redacting past `&` would eat the rest of the message."""
+        out = redact_secrets(f"https://x/y?key={SECRET}&model=gpt-oss-120b failed")
+        assert "model=gpt-oss-120b failed" in out
+        assert SECRET not in out
+
+    def test_ordinary_text_is_untouched(self):
+        assert redact_secrets("connection refused") == "connection refused"
+
+    def test_none_and_empty_are_safe(self):
+        assert redact_secrets(None) == ""
+        assert redact_secrets("") == ""

--- a/tests/test_provider_config_errors.py
+++ b/tests/test_provider_config_errors.py
@@ -593,3 +593,125 @@ class TestTheFallbackProviderThrottlesTheSameWay:
             assert "MAX_THROTTLE_WAIT_SECONDS = " not in source, (
                 f"{module.__name__} defines its own bound — they will drift"
             )
+
+
+class TestTheEmergencyFallbackHadItToo:
+    """
+    The third copy of the same bug, in the provider the router reaches for
+    last. Every non-2xx went through `raise_for_status` into one `except`
+    that recorded a circuit-breaker failure and returned the raw urllib
+    message — so a rejected key, a retired model, an empty account and a
+    throttle were indistinguishable, all four opened the breaker, and none of
+    the first three can recover by waiting.
+
+    Opening this breaker on a fault that will not heal is precisely how one
+    misconfiguration becomes "all providers down".
+    """
+
+    @staticmethod
+    def _resp(status, retry_after=None, payload=None, text='{"ok": true}'):
+        r = MagicMock()
+        r.status_code = status
+        r.headers = {"Retry-After": str(retry_after)} if retry_after is not None else {}
+        r.json.return_value = payload or {
+            "choices": [{"message": {"content": text}}],
+            "usage": {},
+        }
+
+        def _raise():
+            if status >= 400:
+                import requests
+
+                raise requests.exceptions.HTTPError(f"{status} Client Error", response=r)
+
+        r.raise_for_status.side_effect = _raise
+        return r
+
+    def _call(self, responses, monkeypatch, max_wait=10):
+        from app.ai.providers import base as base_mod
+        from app.ai.providers import openrouter as orx
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-key")
+        monkeypatch.setattr(base_mod, "MAX_THROTTLE_WAIT_SECONDS", max_wait)
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        slept = []
+        with (
+            patch.object(orx, "get_breaker", return_value=breaker),
+            patch.object(orx.http_requests, "post", side_effect=responses),
+            patch.object(orx.time, "sleep", side_effect=slept.append),
+        ):
+            result, meta = orx.OpenRouterProvider().ask("sys", "user")
+        return result, meta, breaker, slept
+
+    @pytest.mark.parametrize("status", [400, 401, 402, 403, 404])
+    def test_a_permanent_fault_does_not_open_the_breaker(self, status, monkeypatch):
+        _r, meta, breaker, _s = self._call([self._resp(status, payload={})], monkeypatch)
+        assert not breaker.record_failure.called, f"{status} must not count as an outage"
+        assert is_configuration_error(meta.error), f"got {meta.error!r}"
+
+    def test_out_of_credit_says_so(self, monkeypatch):
+        _r, meta, _b, _s = self._call(
+            [self._resp(402, payload={"error": {"code": 402, "message": "Insufficient credits"}})],
+            monkeypatch,
+        )
+        assert "credit" in meta.error.lower(), f"got {meta.error!r}"
+
+    def test_a_short_throttle_is_waited_out_and_not_counted(self, monkeypatch):
+        result, meta, breaker, slept = self._call(
+            [self._resp(429, retry_after=5), self._resp(200)], monkeypatch
+        )
+        assert slept == [5.0]
+        assert not breaker.record_failure.called, "a throttle we waited out is not a failure"
+        assert meta.error is None
+        assert result == {"ok": True}
+
+    def test_a_persistent_throttle_does_count(self, monkeypatch):
+        _r, meta, breaker, slept = self._call(
+            [self._resp(429, retry_after=4), self._resp(429, retry_after=9)], monkeypatch
+        )
+        assert slept == [4.0]
+        assert meta.error == "RATE_LIMIT:9", f"got {meta.error!r}"
+        assert breaker.record_failure.called
+
+    def test_a_long_delay_is_reported_rather_than_waited_for(self, monkeypatch):
+        _r, meta, _b, slept = self._call([self._resp(429, retry_after=900)], monkeypatch)
+        assert slept == []
+        assert meta.error == "RATE_LIMIT:900"
+
+    def test_waiting_can_be_disabled(self, monkeypatch):
+        _r, meta, _b, slept = self._call(
+            [self._resp(429, retry_after=5)], monkeypatch, max_wait=0
+        )
+        assert slept == []
+        assert meta.error == "RATE_LIMIT:5"
+
+    def test_a_real_outage_still_counts(self, monkeypatch):
+        _r, meta, breaker, _s = self._call([self._resp(500, payload={})], monkeypatch)
+        assert breaker.record_failure.called, "5xx is a genuine outage — the breaker exists for it"
+        assert not is_configuration_error(meta.error)
+
+    def test_the_key_is_read_per_call(self, monkeypatch):
+        """
+        It was captured in __init__ from a constant read at import. The router
+        builds this provider lazily and gates it on a live os.environ read, so
+        a key set after import produced a provider the router believed was
+        configured and that answered `no_api_key` for the rest of the process.
+        """
+        from app.ai.providers.openrouter import OpenRouterProvider
+
+        provider = OpenRouterProvider()
+        monkeypatch.setenv("OPENROUTER_API_KEY", "set-after-construction")
+        assert provider.api_key == "set-after-construction"
+
+    def test_all_three_providers_share_one_throttle_bound(self):
+        import inspect
+
+        from app.ai.providers import gemini, groq, openrouter
+
+        for module in (groq, gemini, openrouter):
+            source = inspect.getsource(module)
+            assert "throttle_pause" in source, f"{module.__name__} must use the shared helper"
+            assert "MAX_THROTTLE_WAIT_SECONDS = " not in source, (
+                f"{module.__name__} defines its own bound — they will drift"
+            )

--- a/tests/test_week1_fixes.py
+++ b/tests/test_week1_fixes.py
@@ -57,21 +57,24 @@ class TestOpenRouterProvider:
         from app.ai.providers.openrouter import DEFAULT_MODEL
         assert ":free" in DEFAULT_MODEL
 
-    def test_no_api_key_returns_error(self):
+    def test_no_api_key_returns_error(self, monkeypatch):
         from app.ai.providers.openrouter import OpenRouterProvider
+        monkeypatch.setenv("OPENROUTER_API_KEY", "")
+        monkeypatch.setattr(
+            "app.ai.providers.openrouter.OPENROUTER_API_KEY", "", raising=False
+        )
         p = OpenRouterProvider.__new__(OpenRouterProvider)
         p._model = "mistralai/mistral-7b-instruct:free"
-        p._api_key = ""
         with patch('app.ai.providers.openrouter.get_breaker') as mb:
             mb.return_value.is_available.return_value = True
             result, meta = p.ask("sys", "user")
         assert meta.error == "no_api_key"
 
-    def test_circuit_open_returns_error(self):
+    def test_circuit_open_returns_error(self, monkeypatch):
         from app.ai.providers.openrouter import OpenRouterProvider
         p = OpenRouterProvider.__new__(OpenRouterProvider)
         p._model = "mistralai/mistral-7b-instruct:free"
-        p._api_key = "sk-test"
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
         with patch('app.ai.providers.openrouter.get_breaker') as mb:
             mb.return_value.is_available.return_value = False
             result, meta = p.ask("sys", "user")
@@ -93,11 +96,11 @@ class TestOpenRouterProvider:
             src = f.read()
         assert 'LLMProvider._extract_json' not in src
 
-    def test_api_failure_records_failure(self):
+    def test_api_failure_records_failure(self, monkeypatch):
         from app.ai.providers.openrouter import OpenRouterProvider
         p = OpenRouterProvider.__new__(OpenRouterProvider)
         p._model = "mistralai/mistral-7b-instruct:free"
-        p._api_key = "sk-test"
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
         with patch('app.ai.providers.openrouter.get_breaker') as mb:
             mb.return_value.is_available.return_value = True
             mb.return_value.record_failure = MagicMock()


### PR DESCRIPTION
## Summary

Three findings from checking what the previous fix actually left behind, plus two follow-ons the first fix exposed. The throttle fix worked — run #9 scored all six `/fix` cases at 1.0. The five review cases still came back empty, and chasing that turned up the real cause.

## 1. The review half of the eval has never measured anything

`_review_code` **returns** `(markdown, inline_comments)`. Its own docstring says so:

> Returns (review_markdown, inline_comments). The caller decides where each goes. **This function posts nothing itself.**

The harness patched `gh_post`, collected what it caught, and threw the return value away. So the scored output was always `""`.

Measured, with a stubbed provider that answers perfectly:

```
gh_post calls        : 0
returned markdown len: 171
```

Every review case has come back empty for as long as this harness has existed. Yesterday it was read as a rate limit; before that, as a quality regression. It was the harness.

The harness now scores the body, the line-anchored comments, and anything the fallback path did post. Same stub, after the fix: **5 of 5 review cases score, 0 blocked**. The varied pass/fail is the scorer correctly discriminating against a deliberately generic stub answer — `review-clean-change` fails `must_not_mention: critical` because the stub invented a critical issue on a clean file, which is the scorer working.

A test pins the bug itself: capturing only `gh_post` yields nothing, whatever the provider does. Reverting the harness makes the test fail with the exact `BLOCKED` lines the nightly run printed.

This is the failure mode this file's own comments warn about, in the file that warns about it.

## 2. The Gemini API key was written into the logs in plaintext

The key was sent as a URL query parameter. `requests` quotes the URL in every exception it raises:

```
HTTPSConnectionPool(host='generativelanguage.googleapis.com', port=443):
Max retries exceeded with url:
/v1beta/models/gemini-1.5-flash:generateContent?key=AIzaSy...
```

That string was assigned to `LLMResponse.error` and logged by the router as `router.primary_failed ... error=...`. One connection error — ordinary on a free-tier host — wrote the credential into the deployment's logs, where it stays.

Two independent guards, because the cost of being wrong once is a rotated key:

- the key travels in the `x-goog-api-key` header, so no exception message can quote it (the API accepts either form);
- anything that still reaches an error string is redacted, covering a redirect or a future edit that puts one back.

Verified against the exception text `requests` actually produces. The key reached both `LLMResponse.error` and the breaker's failure reason before, and neither after; the three tests fail against the previous code.

## 3. The emergency fallback had the 4xx and throttle bug too

The third copy, in the provider the router reaches for **last**. Every non-2xx went through `raise_for_status` into one `except` that recorded a circuit-breaker failure and returned the raw urllib message — so a rejected key, a retired model, an empty account and a throttle were indistinguishable. All four opened the breaker; none of the first three can recover by waiting.

That is the worst place left for it: opening this breaker on a fault that will not heal is exactly how one misconfiguration becomes "all providers down".

| response | before | after |
|---|---|---|
| 401 bad key | 1 breaker failure | **0** — names the key |
| 402 out of credit | 1 breaker failure | **0** — says "out of credit" |
| 404 retired model | 1 breaker failure | **0** — names the model |
| 429, `Retry-After: 5` | 1 breaker failure, no answer | **0** — waits 5s, **answers** |
| 500 real outage | 1 breaker failure | 1 — unchanged |

`402` is new to the shared classifier: an empty account is billing, not a bad key, and telling an operator to regenerate a working key sends them the wrong way.

Also here: the key was captured in `__init__` from a constant read at import, while the router builds this provider lazily and gates it on a *live* `os.environ` read — so a key set after import produced a provider the router believed was configured and that answered `no_api_key` for the rest of the process. Read per call now, like the other two.

The request was built in three near-identical places; it is built in one now. Three copies is how this bug survived being fixed twice.

## Two follow-ons the first fix exposed

Both were harmless only while the harness read nothing.

- **The capture buffer was shared across retry attempts.** `_attempt` retries a case that came back empty, so a retry would have scored the second try's review joined to the first try's. Cleared per attempt now.
- **`looks_blocked` matched its degraded-reply markers at any length.** "rate limit" and "try again" are ordinary words in a review of retry or throttling code, so a genuine review containing them would be discarded as "the provider never answered" — scoring nothing and reporting infrastructure, the exact mistake that function exists to prevent. The markers now only count in a short output, which is what the comment above them already said: the router's degraded reply is a short sentence. No current case trips it; the bound is there so adding a case about retry logic cannot silently blind the suite again.

## Type of change

- [ ] `feat` — New feature or command
- [x] `fix` — Bug fix
- [ ] `docs` — Documentation only
- [x] `refactor` — Code restructure, no behavior change
- [x] `test` — Adding or updating tests
- [x] `security` — Security fix or scanner
- [ ] `chore` — Dependencies, config, tooling

## Testing

- [x] Tests pass locally — **2179 tests** (up from 2146), via `./scripts/verify.sh` twice, random ordering
- [x] New functionality has tests
- [x] Tested manually — each finding reproduced before the fix and re-measured after

Every new test was run against the *unfixed* code first, reverting only the source file so the test itself stayed in place. The harness test fails with the same `BLOCKED` output the nightly run printed; the three leak tests fail with the key visible in the assertion message; the OpenRouter tests fail on the breaker count; the `looks_blocked` test fails on the long review.

**Two existing tests were wrong and are fixed here.** They set `p._api_key` directly — an attribute the provider no longer has — so they configured nothing and ran against whatever the ambient environment held. One of them reached the real `openrouter.ai` over the network during the test run. They set the environment now.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or API keys in code
- [x] Layer boundaries respected (`core/` has no side effects, etc.)
- [x] CONTRIBUTING.md guidelines followed