### PR TITLE
fix(security): a value that says it is not a credential was reported as one

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Done. ✈️
 | | |
 |---|---|
 | Modules | 91 |
-| Lines of code | 20,343 |
+| Lines of code | 20,353 |
 | Slash commands | 27 |
 | MCP tools | 9 |
 | Internal imports | 278 |

--- a/app/security/enhanced_secrets.py
+++ b/app/security/enhanced_secrets.py
@@ -392,6 +392,16 @@ _PLACEHOLDER_WORDS = frozenset(
 # words rather than one.
 _PLACEHOLDER_PHRASES = (
     "not real",
+    # "not a real credential" is how people actually write it, and the phrase
+    # above misses it for the one word in between. This scanner opened a
+    # CRITICAL "rotate ALL exposed credentials NOW" issue against the literal
+    # string `bench-secret-not-a-real-credential`, while the same line with
+    # `test-` instead of `bench-` was silently clean -- suppressed by the
+    # unrelated prefix rule, not by anything the value said about itself.
+    #
+    # A false critical is not a harmless over-report: it is what teaches
+    # people to close these unread.
+    "not a real",
     "change me",
     "replace with",
     "insert key",

--- a/docs/diagrams/codegraph.json
+++ b/docs/diagrams/codegraph.json
@@ -1402,7 +1402,7 @@
       "id": "app.security.enhanced_secrets",
       "path": "app/security/enhanced_secrets.py",
       "layer": "security",
-      "loc": 803,
+      "loc": 813,
       "functions": 18,
       "classes": 1,
       "is_package": false,
@@ -2905,7 +2905,7 @@
   "stats": {
     "modules": 91,
     "edges": 278,
-    "total_loc": 20343,
+    "total_loc": 20353,
     "layers": [
       "ai",
       "core",
@@ -2944,7 +2944,7 @@
       },
       {
         "id": "app.security.enhanced_secrets",
-        "loc": 803,
+        "loc": 813,
         "fan_in": 4,
         "fan_out": 0
       },

--- a/tests/test_placeholder_secrets.py
+++ b/tests/test_placeholder_secrets.py
@@ -250,3 +250,64 @@ class TestPlaceholderWordsNeverSuppressARealSecret:
             if not scan_diff(f'+t = "{token}"', file_path="app/x.py"):
                 misses += 1
         assert misses == 0, f"{misses}/3000 real tokens missed"
+
+
+class TestSelfDeclaredNonCredentials:
+    """
+    The scanner opened a CRITICAL "rotate ALL exposed credentials NOW" issue
+    (#92) against this literal string:
+
+        os.environ["GITHUB_WEBHOOK_SECRET"] = "bench-secret-not-a-real-credential"
+
+    The value says what it is. What made it a false positive rather than a
+    near miss is that the *same line* with `test-` in place of `bench-` was
+    silently clean — suppressed by the unrelated prefix rule, not by anything
+    the value declared about itself. The phrase list had "not real" and the
+    value reads "not a real".
+
+    A false critical is not a harmless over-report. It is what teaches people
+    to close these unread, and this scanner is the product's headline feature.
+    """
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'os.environ["GITHUB_WEBHOOK_SECRET"] = "bench-secret-not-a-real-credential"',
+            'SECRET = "this-is-not-a-real-credential"',
+            'WEBHOOK_SECRET = "not-a-real-credential"',
+            'TOKEN = "not a real token"',
+        ],
+    )
+    def test_a_value_that_says_it_is_not_a_credential_is_not_flagged(self, line):
+        assert scan_diff("+" + line) == [], line
+
+    def test_the_prefix_and_the_declaration_now_agree(self):
+        """
+        The tell that this was a bug and not a tuning choice: two spellings of
+        the same fixture disagreed, and neither verdict came from the part of
+        the value that says it is a fixture.
+        """
+        bench = 'SECRET = "bench-secret-not-a-real-credential"'
+        test = 'SECRET = "test-secret-not-a-real-credential"'
+        assert scan_diff("+" + bench) == scan_diff("+" + test) == []
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'SECRET = "kJ8Fq2mZvR7nT4wXpL9cD6bH3yG5sA1e-not-a-real-credential"',
+            'SECRET = "not-a-real-kJ8Fq2mZvR7nT4wXpL9cD6bH3yG5sA1e"',
+            'API_KEY = "kJ8Fq2mZvR7nT4wXpL9cD6bH3yG5sA1e"  # not a real credential',
+            'SECRET = "kJ8Fq2mZvR7nT4wXpnot-a-realL9cD6bH3yG5sA1e"',
+        ],
+    )
+    def test_the_declaration_cannot_hide_real_key_material(self, line):
+        """
+        The security question for any loosening of a secret scanner: can the
+        new marker be appended to a real credential to smuggle it past?
+
+        No — `_has_key_material` still refuses to let a placeholder word
+        suppress a value that carries a random token, which is the guard the
+        rest of this file is built on. Measured over 12,000 generated
+        credentials across these four shapes: zero missed.
+        """
+        assert scan_diff("+" + line), f"real key material must survive the phrase: {line}"


### PR DESCRIPTION
## Summary

Closes the false positive behind open issue #92, which the scanner filed against itself.

The scanner opened a **CRITICAL** "rotate ALL exposed credentials NOW" issue against this literal string:

```python
os.environ["GITHUB_WEBHOOK_SECRET"] = "bench-secret-not-a-real-credential"
```

## Why this is a bug and not a tuning choice

The same line with `test-` instead of `bench-` was **silently clean**:

```
FLAGGED  ... = "bench-secret-not-a-real-credential"
clean    ... = "test-secret-not-a-real-credential"
```

Neither verdict came from the part of the value that says it is a fixture. `test-` is suppressed by an unrelated *prefix* rule; the phrase list held `"not real"` while the value reads `"not a real"`. Two spellings of the same fixture disagreed, for reasons unrelated to what either one declared about itself.

A false critical is not a harmless over-report. It is what teaches people to close these unread — and this scanner is the product's headline feature.

## The security question

Any loosening of a secret scanner has to answer one question: can the new marker be appended to a real credential to smuggle it past?

It cannot. `_has_key_material` still refuses to let a placeholder word suppress a value carrying a random token — the guard the rest of this file is built on. Measured over **12,000 generated credentials**, 3,000 in each of four shapes:

| shape | missed |
|---|---|
| `"<token>-not-a-real-credential"` | **0** / 3000 |
| `"not-a-real-<token>"` | **0** / 3000 |
| `"<token>"  # not a real credential` | **0** / 3000 |
| `"<tok>not-a-real<en>"` (phrase spliced inside) | **0** / 3000 |

## One pre-existing gap, reported not fixed

While building the adversarial suite I found that a credential embedded in a **space-separated** quoted string is not matched by the generic-token pattern at all:

```
clean  GITHUB_WEBHOOK_SECRET = "not a real credential Av8QP9ec9djZVbc49eMkTCiJqGkbKc4k69TfVTbW"
clean  GITHUB_WEBHOOK_SECRET = "some words here Av8QP9ec9djZVbc49eMkTCiJqGkbKc4k69TfVTbW"
FLAGGED GITHUB_WEBHOOK_SECRET = "Av8QP9ec9djZVbc49eMkTCiJqGkbKc4k69TfVTbW"
```

The second line has no placeholder phrase in it, which is the point: this is the pattern requiring a contiguous token, not the placeholder logic. **Verified identical before and after this change** by reverting the source file and re-running — this PR neither causes it nor widens it.

I have not fixed it. Matching long random runs inside arbitrary prose would undo the false-positive work this file already carries (three separate passes are documented in its comments), and that trade deserves its own decision rather than being smuggled in behind a one-line phrase addition.

## Type of change

- [ ] `feat` — New feature or command
- [x] `fix` — Bug fix
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code restructure, no behavior change
- [x] `test` — Adding or updating tests
- [x] `security` — Security fix or scanner
- [ ] `chore` — Dependencies, config, tooling

## Testing

- [x] Tests pass locally — **2194 tests**, via `./scripts/verify.sh` twice, random ordering
- [x] New functionality has tests
- [x] Tested manually — reproduced from the exact string in issue #92

The four suppression tests were run against the unfixed scanner first, reverting only the source file so the tests stayed in place; all four fail there. The four adversarial tests pass both before and after, which is correct — a change that made them newly pass would mean the guard had been weakened.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or API keys in code
- [x] Layer boundaries respected (`core/` has no side effects, etc.)
- [x] CONTRIBUTING.md guidelines followed

---
_Generated by [Claude Code](https://claude.ai/code/session_012iV5tKCGtjHZBAvnbfwM62)_