### PR TITLE
fix(ai): the emergency fallback pointed at a model OpenRouter retired

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,26 @@ EVENT_QUEUE_MAX_LEN=200
 # that reason. Unset means the router's own defaults.
 # LLM_PRIMARY_MODEL=openai/gpt-oss-120b
 # LLM_FALLBACK_MODEL=openai/gpt-oss-20b
+# LLM_GEMINI_MODEL=          # run the catalogue command below for valid ids
+
+# A hardcoded model id is a dated claim about someone else's product. When the
+# provider retired every Llama chat model this deployment returned 404 for six
+# days, and the fix was a string nobody knew to change.
+#
+# So a model id that the provider says does not exist is no longer fatal: the
+# bot reads the provider's own catalogue, picks the best currently-served model
+# in the same tier, says so in the logs and on /health, and carries on. Set the
+# variables above to pin a specific model and the substitution never happens --
+# an explicit choice is always honoured.
+#
+# See what is served right now, and what would be picked:
+#   python -m app.ai.model_catalog
+#
+# How long a fetched catalogue is trusted before being re-read. Unset: 6 hours.
+# LLM_CATALOG_TTL_SECONDS=21600
+#
+# Set to 0 to disable substitution entirely and fail on a retired id instead.
+# LLM_MODEL_AUTOHEAL=1
 
 # How long to wait out a provider rate limit before giving up on the request.
 #

--- a/.env.example
+++ b/.env.example
@@ -120,9 +120,12 @@ EVENT_QUEUE_MAX_LEN=200
 #
 # So a model id that the provider says does not exist is no longer fatal: the
 # bot reads the provider's own catalogue, picks the best currently-served model
-# in the same tier, says so in the logs and on /health, and carries on. Set the
-# variables above to pin a specific model and the substitution never happens --
-# an explicit choice is always honoured.
+# in the same tier, says so in the logs and on /health, and carries on.
+#
+# This applies to a pinned id above as well as to the built-in default. A
+# retired id is unusable however it was chosen, and refusing to work does not
+# honour the operator's intent -- it just goes down. The substitution is loud,
+# never silent, and lasts only until the process restarts or the id is fixed.
 #
 # See what is served right now, and what would be picked:
 #   python -m app.ai.model_catalog

--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ Done. ✈️
 <!-- autopilot:stats:start -->
 | | |
 |---|---|
-| Modules | 91 |
-| Lines of code | 20,353 |
+| Modules | 92 |
+| Lines of code | 20,847 |
 | Slash commands | 27 |
 | MCP tools | 9 |
-| Internal imports | 278 |
+| Internal imports | 284 |
 <!-- autopilot:stats:end -->
 
 <sub>Regenerated from the code by CI — see [managed README sections](#managed-readme-sections).</sub>
@@ -224,7 +224,7 @@ code. Explore it interactively at [`/graph`](#codebase-map), or regenerate with
 <!-- autopilot:architecture:start -->
 ```mermaid
 graph LR
-    ai["ai<br/>15 modules"]
+    ai["ai<br/>16 modules"]
     core["core<br/>24 modules"]
     github["github<br/>8 modules"]
     handlers["handlers<br/>23 modules"]

--- a/app/ai/model_catalog.py
+++ b/app/ai/model_catalog.py
@@ -1,0 +1,224 @@
+"""
+app/ai/model_catalog.py
+Ask each provider which models it actually serves.
+
+A hardcoded model id is a dated assertion about someone else's product. This
+deployment learned that the expensive way: the provider retired every Llama
+chat model, every AI command returned 404 for six days, and the fix was a
+string in an environment variable that nobody knew to change.
+
+Replacing one hardcoded id with a newer hardcoded id does not fix that — it
+resets the timer. What fixes it is asking the provider.
+
+Two uses:
+
+  * `inventory()` — what is served right now, for an operator choosing a model
+    or a preflight reporting one that has gone.
+  * `best_model()` — the strongest currently-served model for a tier, matched
+    by FAMILY pattern rather than exact id, so a version bump inside a family
+    (…-120b -> …-121b) is picked up without a code change.
+
+Nothing here is on the hot path. Providers consult it only after the provider
+itself has said a model does not exist, so a correctly-configured deployment
+never pays for it.
+
+Every function fails open and returns something usable. A catalogue lookup
+that raised would replace a precise "the model is gone" with a stack trace
+about the lookup, which is the failure this module exists to prevent.
+"""
+
+import logging
+import os
+import re
+import threading
+import time
+
+log = logging.getLogger(__name__)
+
+# Cached because the answer changes on the provider's release cadence, not
+# ours, and because this is consulted while a webhook is waiting.
+CATALOG_TTL_SECONDS = float(os.environ.get("LLM_CATALOG_TTL_SECONDS", "21600"))  # 6h
+_CATALOG_TIMEOUT = 10
+
+_cache: dict[str, tuple[list[str], float]] = {}
+_cache_lock = threading.Lock()
+
+
+# ── Where each provider publishes its catalogue ───────────────────────────────
+#
+# `key_env` empty means the endpoint needs no credential.
+_ENDPOINTS = {
+    "groq": {
+        "url": "https://api.groq.com/openai/v1/models",
+        "key_env": "GROQ_API_KEY",
+        "auth": "bearer",
+    },
+    "openrouter": {
+        "url": "https://openrouter.ai/api/v1/models",
+        "key_env": "",  # public catalogue
+        "auth": "",
+    },
+    "gemini": {
+        "url": "https://generativelanguage.googleapis.com/v1beta/models",
+        "key_env": "GEMINI_API_KEY",
+        "auth": "x-goog-api-key",
+    },
+}
+
+PROVIDERS = tuple(_ENDPOINTS)
+
+
+def _extract_ids(provider: str, payload: dict) -> list[str]:
+    """Provider catalogues disagree about shape; normalise to a list of ids."""
+    if provider == "gemini":
+        # {"models": [{"name": "models/gemini-x", "supportedGenerationMethods": [...]}]}
+        out = []
+        for m in payload.get("models") or []:
+            name = str(m.get("name", "")).removeprefix("models/")
+            methods = m.get("supportedGenerationMethods") or []
+            # Embedding and token-counting models are served here too, and
+            # asking one of them to review code returns a 400 that reads like
+            # an outage.
+            if name and (not methods or "generateContent" in methods):
+                out.append(name)
+        return out
+    # OpenAI-compatible: {"data": [{"id": "..."}]}
+    return [str(m.get("id", "")) for m in (payload.get("data") or []) if m.get("id")]
+
+
+def available_models(provider: str, *, refresh: bool = False) -> list[str]:
+    """
+    Sorted model ids the provider serves right now, or [] when unknown.
+
+    [] means "could not find out" — never "the provider has no models". Callers
+    must treat it as no information rather than as an answer, because acting on
+    an empty catalogue would take a working deployment down.
+    """
+    spec = _ENDPOINTS.get(provider)
+    if not spec:
+        return []
+
+    now = time.time()
+    if not refresh:
+        with _cache_lock:
+            hit = _cache.get(provider)
+        if hit and now - hit[1] < CATALOG_TTL_SECONDS:
+            return list(hit[0])
+
+    key = os.environ.get(spec["key_env"], "").strip() if spec["key_env"] else ""
+    if spec["key_env"] and not key:
+        return []
+
+    headers = {}
+    if spec["auth"] == "bearer":
+        headers["Authorization"] = f"Bearer {key}"
+    elif spec["auth"] == "x-goog-api-key":
+        headers["x-goog-api-key"] = key
+
+    try:
+        import requests
+
+        r = requests.get(spec["url"], headers=headers, timeout=_CATALOG_TIMEOUT)
+        if r.status_code != 200:
+            log.warning(f"model_catalog.unavailable provider={provider} status={r.status_code}")
+            return []
+        ids = sorted({m for m in _extract_ids(provider, r.json()) if m})
+    except Exception as exc:
+        # Redacted: the Gemini endpoint took its key in the query string once,
+        # and requests quotes the URL in every exception it raises.
+        from app.core.redaction import redact_secrets
+
+        log.warning(f"model_catalog.failed provider={provider}: {redact_secrets(str(exc))[:120]}")
+        return []
+
+    with _cache_lock:
+        _cache[provider] = (ids, now)
+    return list(ids)
+
+
+def clear_cache() -> None:
+    with _cache_lock:
+        _cache.clear()
+
+
+# ── Preference, by family rather than by exact id ─────────────────────────────
+#
+# Ordered most-preferred first. Each entry is a regex matched against the
+# served id, so a provider bumping a version inside a family is picked up with
+# no code change — which is the whole point. An id matching nothing here is
+# still usable; it just sorts last.
+#
+# "quality" is the tier the router reaches for on code review and fixes;
+# "speed" is the cheaper fallback tier. Ordering within a provider reflects
+# what that provider's free tier actually serves, read off its own catalogue —
+# see `python -m app.ai.model_catalog`.
+_PREFERENCES: dict[tuple[str, str], tuple[str, ...]] = {}
+
+# Ids that exist but must never be auto-selected: not chat models, or
+# deliberately not general-purpose. Guarded because picking one produces a 400
+# that reads like an outage rather than a bad choice.
+_EXCLUDE = re.compile(
+    r"(whisper|tts|guard|embed|aqa|vision-only|moderation|distil-whisper|prompt-guard)",
+    re.IGNORECASE,
+)
+
+
+def _rank(provider: str, tier: str, model_id: str) -> tuple[int, str]:
+    prefs = _PREFERENCES.get((provider, tier), ())
+    for index, pattern in enumerate(prefs):
+        if re.search(pattern, model_id, re.IGNORECASE):
+            return index, model_id
+    return len(prefs), model_id
+
+
+def best_model(provider: str, tier: str = "quality", *, exclude: tuple[str, ...] = ()) -> str:
+    """
+    The best currently-served model for this tier, or "" when unknown.
+
+    "" is returned whenever the catalogue could not be read or nothing passes
+    the filters. Callers keep their configured model in that case: a guess is
+    worse than the id an operator chose, and silently switching models on an
+    unreadable catalogue would be a change nobody asked for.
+    """
+    candidates = [
+        m for m in available_models(provider) if not _EXCLUDE.search(m) and m not in exclude
+    ]
+    if not candidates:
+        return ""
+    if provider == "openrouter":
+        # Only the `:free` variants cost nothing, and this provider is the
+        # emergency fallback — reaching it should never start a bill.
+        free = [m for m in candidates if m.endswith(":free")]
+        candidates = free or candidates
+    return min(candidates, key=lambda m: _rank(provider, tier, m))
+
+
+def inventory() -> dict[str, list[str]]:
+    """Everything every configured provider serves. For operators and CI."""
+    return {p: available_models(p) for p in PROVIDERS}
+
+
+def format_inventory() -> str:
+    lines = []
+    for provider, models in inventory().items():
+        spec = _ENDPOINTS[provider]
+        if not models:
+            why = (
+                f"{spec['key_env']} not set"
+                if spec["key_env"] and not os.environ.get(spec["key_env"], "").strip()
+                else "catalogue unavailable"
+            )
+            lines.append(f"{provider}: — ({why})")
+            continue
+        lines.append(f"{provider}: {len(models)} models")
+        for m in models:
+            mark = "  " if _EXCLUDE.search(m) else "* "
+            lines.append(f"    {mark}{m}")
+        for tier in ("quality", "speed"):
+            pick = best_model(provider, tier)
+            lines.append(f"    -> best[{tier}]: {pick or '(none)'}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":  # pragma: no cover - operator tool
+    print(format_inventory())

--- a/app/ai/model_catalog.py
+++ b/app/ai/model_catalog.py
@@ -143,32 +143,84 @@ def clear_cache() -> None:
 
 # ── Preference, by family rather than by exact id ─────────────────────────────
 #
-# Ordered most-preferred first. Each entry is a regex matched against the
-# served id, so a provider bumping a version inside a family is picked up with
-# no code change — which is the whole point. An id matching nothing here is
-# still usable; it just sorts last.
+# Ordered most-preferred first, each entry a regex matched against the served
+# id. Families, not exact ids: a provider bumping a version inside a family
+# (qwen3.6 -> qwen3.8, gpt-oss-120b -> a larger successor) is picked up with no
+# code change, which is the entire point of this module.
 #
-# "quality" is the tier the router reaches for on code review and fixes;
-# "speed" is the cheaper fallback tier. Ordering within a provider reflects
-# what that provider's free tier actually serves, read off its own catalogue —
-# see `python -m app.ai.model_catalog`.
-_PREFERENCES: dict[tuple[str, str], tuple[str, ...]] = {}
+# Derived from each provider's own catalogue as printed by
+# `python -m app.ai.model_catalog` — not from memory. An id matching nothing
+# here is still selectable; it just sorts last, so a provider shipping a family
+# nobody anticipated degrades to "some served model" rather than to nothing.
+#
+# The gemini patterns are the one unverified set: no GEMINI_API_KEY is
+# configured in CI, so its catalogue could not be read. That costs nothing —
+# a pattern that matches no served id simply never fires, and selection falls
+# through to the generic ordering below.
+_PREFERENCES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("groq", "quality"): (
+        r"^openai/gpt-oss-\d{3,}b$",  # 120b, and any larger successor
+        r"^qwen/qwen[\d.]+-\d+b$",
+        r"^groq/compound$",
+        r"^openai/gpt-oss-\d{1,2}b$",  # 20b
+        r"^groq/compound-mini$",
+    ),
+    ("groq", "speed"): (
+        r"^openai/gpt-oss-\d{1,2}b$",
+        r"^groq/compound-mini$",
+        r"^qwen/qwen[\d.]+-\d+b$",
+        r"^groq/compound$",
+        r"^openai/gpt-oss-\d{3,}b$",
+    ),
+    ("openrouter", "quality"): (
+        # `super` before `ultra` on purpose. This provider is the EMERGENCY
+        # fallback, reached only when the other two are already failing, so the
+        # job is to answer at all. The largest free model on a free tier is
+        # also the most contended one, and a 550B that queues is worth less
+        # here than a 120B that replies.
+        r"nemotron-[\d.]+-super",
+        r"nemotron-[\d.]+-ultra",
+        r"^minimax/",
+        r"^z-ai/glm-",
+        r"^thinkingmachines/inkling(:|$)",
+        r"^google/gemma-",
+        r"^poolside/laguna-s",
+    ),
+    ("openrouter", "speed"): (
+        r"nemotron-[\d.]+-lightning",
+        r"^google/gemma-",
+        r"^liquid/lfm",
+        r"^poolside/laguna-xs",
+        r"^thinkingmachines/inkling-small",
+        r"^minimax/",
+    ),
+    ("gemini", "quality"): (r"flash-latest", r"pro-latest", r"flash", r"pro"),
+    ("gemini", "speed"): (r"flash-lite", r"flash-latest", r"flash", r"pro"),
+}
 
-# Ids that exist but must never be auto-selected: not chat models, or
-# deliberately not general-purpose. Guarded because picking one produces a 400
-# that reads like an outage rather than a bad choice.
+# Served here, but never a sane automatic choice: not chat models at all
+# (speech, embeddings, rerankers) or classifiers that answer a different
+# question. Picking one produces a 400 that reads like an outage rather than
+# like a bad choice, which is the worst way to fail.
 _EXCLUDE = re.compile(
-    r"(whisper|tts|guard|embed|aqa|vision-only|moderation|distil-whisper|prompt-guard)",
+    r"(whisper|/tts|-tts|text-to-speech|orpheus|guard|embed|rerank|aqa|moderation"
+    r"|content-safety|speech|transcri)",
     re.IGNORECASE,
 )
 
+# Usable, but narrow: tuned for one language, one domain, or one modality. Fine
+# as a last resort, wrong as a default for reviewing code in English.
+_NARROW = re.compile(
+    r"(allam|arabic|saudi|-fin\b|-fin[:-]|omni|vision|note-preview)", re.IGNORECASE
+)
 
-def _rank(provider: str, tier: str, model_id: str) -> tuple[int, str]:
+
+def _rank(provider: str, tier: str, model_id: str) -> tuple[int, int]:
     prefs = _PREFERENCES.get((provider, tier), ())
     for index, pattern in enumerate(prefs):
         if re.search(pattern, model_id, re.IGNORECASE):
-            return index, model_id
-    return len(prefs), model_id
+            return (1 if _NARROW.search(model_id) else 0), index
+    return (1 if _NARROW.search(model_id) else 0), len(prefs)
 
 
 def best_model(provider: str, tier: str = "quality", *, exclude: tuple[str, ...] = ()) -> str:
@@ -190,6 +242,11 @@ def best_model(provider: str, tier: str = "quality", *, exclude: tuple[str, ...]
         # emergency fallback — reaching it should never start a bill.
         free = [m for m in candidates if m.endswith(":free")]
         candidates = free or candidates
+
+    # Descending, so that within one preference bucket the later version wins
+    # (qwen3.8 over qwen3.6). `min` is stable and returns the first of equals,
+    # so iteration order IS the tie-break.
+    candidates.sort(reverse=True)
     return min(candidates, key=lambda m: _rank(provider, tier, m))
 
 
@@ -222,3 +279,77 @@ def format_inventory() -> str:
 
 if __name__ == "__main__":  # pragma: no cover - operator tool
     print(format_inventory())
+
+
+# ── Substitution: what to do when the configured model is gone ────────────────
+#
+# A retired model id is unusable however it was chosen, so this applies to an
+# operator-pinned id as much as to the built-in default. Refusing to work does
+# not honour the operator's intent; it just goes down, which is precisely the
+# six-day outage this module exists to prevent.
+#
+# The substitution is loud, in-process only, and lasts until the process
+# restarts or the configuration is corrected. It is never silent: it logs at
+# ERROR and is reported by /health and the doctor, because a bot quietly
+# answering on a model nobody chose is its own kind of incident.
+_substitutions: dict[str, dict] = {}
+_sub_lock = threading.Lock()
+
+
+def autoheal_enabled() -> bool:
+    return os.environ.get("LLM_MODEL_AUTOHEAL", "1").strip() not in ("0", "false", "no")
+
+
+def effective_model(provider_key: str, configured: str) -> str:
+    """The model to actually ask for: a substitution if one is active."""
+    with _sub_lock:
+        entry = _substitutions.get(provider_key)
+    return entry["to"] if entry else configured
+
+
+def substitute(provider_key: str, provider: str, tier: str, failed_model: str) -> str:
+    """
+    Pick a replacement for a model the provider says it does not serve.
+
+    Returns "" when there is nothing better to do — no catalogue, autoheal
+    disabled, or the catalogue offers nothing but the model that just failed.
+    "" means the caller reports the configuration error exactly as before, so
+    this can only ever turn a hard failure into a working request or leave it
+    unchanged.
+    """
+    if not autoheal_enabled():
+        return ""
+
+    with _sub_lock:
+        active = _substitutions.get(provider_key)
+    if active and active["to"] != failed_model:
+        # Something already substituted; use it rather than re-deriving.
+        return active["to"]
+
+    replacement = best_model(provider, tier, exclude=(failed_model,))
+    if not replacement or replacement == failed_model:
+        return ""
+
+    with _sub_lock:
+        _substitutions[provider_key] = {
+            "from": failed_model,
+            "to": replacement,
+            "provider": provider,
+            "at": time.time(),
+        }
+    log.error(
+        f"model_catalog.substituted provider_key={provider_key} "
+        f"from={failed_model} to={replacement} — the configured model is not "
+        f"served any more; set it to a current id to silence this."
+    )
+    return replacement
+
+
+def active_substitutions() -> dict[str, dict]:
+    with _sub_lock:
+        return {k: dict(v) for k, v in _substitutions.items()}
+
+
+def clear_substitutions() -> None:
+    with _sub_lock:
+        _substitutions.clear()

--- a/app/ai/providers/base.py
+++ b/app/ai/providers/base.py
@@ -14,6 +14,7 @@ That's it. Zero changes to handlers or commands.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import os
+import re
 import time
 
 
@@ -287,7 +288,60 @@ __all__ = [
     "CONFIG_ERROR_PREFIX",
     "MAX_THROTTLE_WAIT_SECONDS",
     "client_error_detail",
+    "is_model_missing",
+    "substituted_model",
     "is_configuration_error",
     "redact_secrets",
     "throttle_pause",
 ]
+
+
+# ── A model that no longer exists ─────────────────────────────────────────────
+#
+# Distinct from every other 4xx: a rejected key needs a human, but a retired
+# model id has an answer the provider itself will give us. The last time one
+# was retired here, every AI command returned 404 for six days.
+_MODEL_GONE = re.compile(
+    r"(model_not_found|does not exist|decommissioned|deprecated|no endpoints found"
+    r"|not found|unknown model|invalid model)",
+    re.IGNORECASE,
+)
+
+
+def is_model_missing(response, status: int) -> bool:
+    """
+    True when this 4xx says the MODEL is the problem, not the credential.
+
+    Deliberately narrow. Substituting a model for a rejected key would swap a
+    precise "your key is invalid" for a confusing "we quietly changed model and
+    it still did not work", so 401/403 never reach here.
+    """
+    if status in (401, 403):
+        return False
+    body = ""
+    try:
+        err = (response.json().get("error") or {}) if response is not None else {}
+        body = f"{err.get('code', '')} {err.get('message', '')} {err.get('status', '')}"
+    except Exception:
+        body = ""
+    return status == 404 or bool(_MODEL_GONE.search(body))
+
+
+def substituted_model(
+    provider_key: str, provider: str, tier: str, failed_model: str, response, status: int
+) -> str:
+    """
+    A replacement for a model the provider says it does not serve, or "".
+
+    "" means "carry on and report the configuration error exactly as before",
+    so this can only turn a hard failure into a working request or leave the
+    behaviour unchanged. It never makes a working call worse.
+    """
+    if not is_model_missing(response, status):
+        return ""
+    try:
+        from app.ai.model_catalog import substitute
+
+        return substitute(provider_key, provider, tier, failed_model)
+    except Exception:  # pragma: no cover - the repair path must never raise
+        return ""

--- a/app/ai/providers/gemini.py
+++ b/app/ai/providers/gemini.py
@@ -13,11 +13,13 @@ import time
 import requests as http_requests
 
 from app.ai.circuit_breaker import get_breaker
+from app.ai.model_catalog import effective_model
 from app.ai.providers.base import (
     LLMProvider,
     LLMResponse,
     client_error_detail,
     redact_secrets,
+    substituted_model,
     throttle_pause,
 )
 
@@ -62,7 +64,7 @@ class GeminiProvider(LLMProvider):
     ) -> LLMResponse:
         # Resolved once so every return path below names the model actually
         # asked for, including the ones that return before the HTTP call.
-        model = gemini_model()
+        model = effective_model("gemini", gemini_model())
 
         # ── STEP 1: Circuit breaker check — MUST be first ─────────────────────
         breaker = get_breaker("gemini")
@@ -142,6 +144,17 @@ class GeminiProvider(LLMProvider):
             # These used to record a breaker failure, which opened the circuit
             # on a fault that cannot recover and reported it as a provider
             # outage. The breaker is left alone now.
+            if r.status_code in (400, 401, 403, 404):
+                # Same repair as the primary: a model the provider no longer
+                # serves is a question the provider itself can answer.
+                replacement = substituted_model(
+                    "gemini", "gemini", "speed", model, r, r.status_code
+                )
+                if replacement:
+                    model = replacement
+                    url = _gemini_url(model)
+                    r = http_requests.post(url, json=body, headers=headers, timeout=timeout)
+
             if r.status_code in (400, 401, 403, 404):
                 detail = client_error_detail(
                     r, r.status_code, model, "GEMINI_API_KEY", GEMINI_MODEL_ENV

--- a/app/ai/providers/groq.py
+++ b/app/ai/providers/groq.py
@@ -17,10 +17,12 @@ import time
 import requests as http_requests
 
 import app.ai.circuit_breaker as cb
+from app.ai.model_catalog import effective_model
 from app.ai.providers.base import (
     LLMProvider,
     LLMResponse,
     client_error_detail,
+    substituted_model,
     throttle_pause,
 )
 from app.core.redis_client import get_redis
@@ -80,6 +82,11 @@ class GroqProvider(LLMProvider):
         self._provider_key = provider_key or _infer_provider_key(self._model)
 
     @property
+    def _tier(self) -> str:
+        """Which tier a replacement must match: the fallback must stay cheap."""
+        return "speed" if self._provider_key == "groq_8b" else "quality"
+
+    @property
     def provider_key(self) -> str:
         """
         Which budget, circuit breaker and quality tier this instance uses.
@@ -107,14 +114,19 @@ class GroqProvider(LLMProvider):
         temperature: float,
         timeout: int,
     ) -> LLMResponse:
+        # Resolved once. `effective_model` returns a substitution when a
+        # previous call found the configured id retired, so every path below --
+        # including the error paths -- names the model actually asked for.
+        model = effective_model(self.provider_key, self._model)
+
         # ── STEP 1: Circuit breaker check — MUST be first ─────────────────────
         breaker = cb.get_breaker(self.provider_key)
         if not breaker.is_available():
             return LLMResponse(
                 text="",
                 provider="groq",
-                model=self._model,
-                error=f"Circuit OPEN for {self._model}",
+                model=model,
+                error=f"Circuit OPEN for {model}",
             )
 
         # ── STEP 2: API key check ─────────────────────────────────────────────
@@ -123,7 +135,7 @@ class GroqProvider(LLMProvider):
             return LLMResponse(
                 text="",
                 provider="groq",
-                model=self._model,
+                model=model,
                 error="GROQ_API_KEY not set",
             )
 
@@ -133,7 +145,7 @@ class GroqProvider(LLMProvider):
             "Content-Type": "application/json",
         }
         body = {
-            "model": self._model,
+            "model": model,
             "max_tokens": max_tokens,
             "temperature": temperature,
             "messages": [
@@ -154,9 +166,7 @@ class GroqProvider(LLMProvider):
                 # holding the thread for. A throttle we successfully waited out
                 # is not a failure and must not count toward the breaker.
                 if pause:
-                    log.info(
-                        f"groq.throttled model={self._model} waiting={pause:g}s then retrying once"
-                    )
+                    log.info(f"groq.throttled model={model} waiting={pause:g}s then retrying once")
                     time.sleep(pause)
                     r = http_requests.post(GROQ_URL, headers=headers, json=body, timeout=timeout)
 
@@ -168,7 +178,7 @@ class GroqProvider(LLMProvider):
                     return LLMResponse(
                         text="",
                         provider="groq",
-                        model=self._model,
+                        model=model,
                         error=f"RATE_LIMIT:{retry_after}",
                     )
 
@@ -181,7 +191,7 @@ class GroqProvider(LLMProvider):
                 return LLMResponse(
                     text="",
                     provider="groq",
-                    model=self._model,
+                    model=model,
                     error=f"Server error {_status}",
                 )
 
@@ -201,14 +211,28 @@ class GroqProvider(LLMProvider):
             # recover on its own, so opening the breaker only replaces a precise
             # error with a vague one. Report these and leave the breaker alone.
             if _status in (401, 403, 404):
-                detail = client_error_detail(
-                    r, _status, self._model, "GROQ_API_KEY", "LLM_PRIMARY_MODEL"
+                # A retired model id is the one 4xx the provider can answer for
+                # us: ask what it serves, take the best in this tier, retry
+                # once. Six days of 404s is what this replaces.
+                replacement = substituted_model(
+                    self.provider_key, "groq", self._tier, model, r, _status
                 )
-                log.error(f"groq.configuration_error status={_status} model={self._model}")
+                if replacement:
+                    model = replacement
+                    body["model"] = model
+                    r = http_requests.post(GROQ_URL, headers=headers, json=body, timeout=timeout)
+                    try:
+                        _status = int(r.status_code)
+                    except (TypeError, ValueError):
+                        _status = 0
+
+            if _status in (401, 403, 404):
+                detail = client_error_detail(r, _status, model, "GROQ_API_KEY", "LLM_PRIMARY_MODEL")
+                log.error(f"groq.configuration_error status={_status} model={model}")
                 return LLMResponse(
                     text="",
                     provider="groq",
-                    model=self._model,
+                    model=model,
                     error=detail,
                 )
 
@@ -227,7 +251,7 @@ class GroqProvider(LLMProvider):
             return LLMResponse(
                 text=text,
                 provider="groq",
-                model=self._model,
+                model=model,
                 prompt_tokens=p_tok,
                 completion_tokens=c_tok,
                 total_tokens=t_tok,
@@ -239,7 +263,7 @@ class GroqProvider(LLMProvider):
             return LLMResponse(
                 text="",
                 provider="groq",
-                model=self._model,
+                model=model,
                 error="Request timed out",
             )
         except Exception as e:
@@ -249,7 +273,7 @@ class GroqProvider(LLMProvider):
             return LLMResponse(
                 text="",
                 provider="groq",
-                model=self._model,
+                model=model,
                 error=err[:200],
             )
 

--- a/app/ai/providers/openrouter.py
+++ b/app/ai/providers/openrouter.py
@@ -22,6 +22,7 @@ from app.ai.providers.base import (
     LLMResponse,
     client_error_detail,
     redact_secrets,
+    substituted_model,
     throttle_pause,
 )
 
@@ -30,8 +31,21 @@ log = logging.getLogger(__name__)
 OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
-# Free model — no cost, decent quality for fallback
-DEFAULT_MODEL = "mistralai/mistral-7b-instruct:free"
+# Free — this provider is the emergency fallback, so reaching it must never
+# start a bill.
+#
+# Was `mistralai/mistral-7b-instruct:free`, which the provider no longer serves:
+# it appears nowhere in the 394 models OpenRouter currently lists, and there is
+# no free Mistral variant at all. Every emergency fallback would have 404'd —
+# the failure was invisible precisely because this path is only reached when
+# things are already going wrong.
+#
+# Read off the provider's own catalogue, not from memory. `a12b` is the active
+# parameter count of a mixture-of-experts model: 120B of knowledge at roughly
+# 12B of latency, which is the right shape for a last resort. If this id is
+# retired too, model_catalog substitutes the best served free model and says so
+# rather than going down again.
+DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b:free"
 
 
 class OpenRouterProvider(LLMProvider):
@@ -40,7 +54,9 @@ class OpenRouterProvider(LLMProvider):
     provider_key = "openrouter"
 
     def __init__(self, model: str = DEFAULT_MODEL):
-        self._model = model
+        from app.ai.model_catalog import effective_model
+
+        self._model = effective_model("openrouter", model)
 
     @property
     def api_key(self) -> str:
@@ -106,6 +122,18 @@ class OpenRouterProvider(LLMProvider):
                     model=self._model,
                     error=f"RATE_LIMIT:{retry_after}",
                 )
+
+        if status in (400, 401, 402, 403, 404):
+            # The emergency fallback pointed at a model OpenRouter had already
+            # retired, so every last resort 404'd -- invisible, because this
+            # path is only reached when things are going wrong already.
+            replacement = substituted_model(
+                "openrouter", "openrouter", "quality", self._model, resp, status
+            )
+            if replacement:
+                self._model = replacement
+                resp = repost()
+                status = getattr(resp, "status_code", 0)
 
         if status in (400, 401, 402, 403, 404):
             detail = client_error_detail(resp, status, self._model, "OPENROUTER_API_KEY")
@@ -178,7 +206,9 @@ class OpenRouterProvider(LLMProvider):
         start = time.time()
         try:
             resp = self._post(body, timeout)
-            resp, stop = self._throttle_or_fault(resp, breaker, lambda: self._post(body, timeout))
+            resp, stop = self._throttle_or_fault(
+                resp, breaker, lambda: self._post({**body, "model": self._model}, timeout)
+            )
             if stop is not None:
                 stop.latency_ms = int((time.time() - start) * 1000)
                 return {}, stop
@@ -246,7 +276,9 @@ class OpenRouterProvider(LLMProvider):
         start = time.time()
         try:
             resp = self._post(body, timeout)
-            resp, stop = self._throttle_or_fault(resp, breaker, lambda: self._post(body, timeout))
+            resp, stop = self._throttle_or_fault(
+                resp, breaker, lambda: self._post({**body, "model": self._model}, timeout)
+            )
             if stop is not None:
                 stop.latency_ms = int((time.time() - start) * 1000)
                 return "", stop

--- a/docs/diagrams/codegraph.json
+++ b/docs/diagrams/codegraph.json
@@ -111,6 +111,26 @@
       ]
     },
     {
+      "id": "app.ai.model_catalog",
+      "path": "app/ai/model_catalog.py",
+      "layer": "ai",
+      "loc": 356,
+      "functions": 12,
+      "classes": 0,
+      "is_package": false,
+      "fan_in": 5,
+      "fan_out": 1,
+      "external_deps": [
+        "app",
+        "logging",
+        "os",
+        "re",
+        "requests",
+        "threading",
+        "time"
+      ]
+    },
+    {
       "id": "app.ai.providers",
       "path": "app/ai/providers/__init__.py",
       "layer": "ai",
@@ -126,12 +146,12 @@
       "id": "app.ai.providers.base",
       "path": "app/ai/providers/base.py",
       "layer": "ai",
-      "loc": 294,
-      "functions": 5,
+      "loc": 348,
+      "functions": 7,
       "classes": 2,
       "is_package": false,
       "fan_in": 7,
-      "fan_out": 2,
+      "fan_out": 3,
       "external_deps": [
         "abc",
         "app",
@@ -146,12 +166,12 @@
       "id": "app.ai.providers.gemini",
       "path": "app/ai/providers/gemini.py",
       "layer": "ai",
-      "loc": 244,
+      "loc": 257,
       "functions": 2,
       "classes": 1,
       "is_package": false,
       "fan_in": 1,
-      "fan_out": 3,
+      "fan_out": 4,
       "external_deps": [
         "app",
         "datetime",
@@ -165,12 +185,12 @@
       "id": "app.ai.providers.groq",
       "path": "app/ai/providers/groq.py",
       "layer": "ai",
-      "loc": 284,
+      "loc": 308,
       "functions": 1,
       "classes": 1,
       "is_package": false,
       "fan_in": 1,
-      "fan_out": 4,
+      "fan_out": 5,
       "external_deps": [
         "app",
         "datetime",
@@ -201,12 +221,12 @@
       "id": "app.ai.providers.openrouter",
       "path": "app/ai/providers/openrouter.py",
       "layer": "ai",
-      "loc": 280,
+      "loc": 312,
       "functions": 0,
       "classes": 1,
       "is_package": false,
       "fan_in": 1,
-      "fan_out": 3,
+      "fan_out": 4,
       "external_deps": [
         "app",
         "logging",
@@ -569,7 +589,7 @@
       "functions": 2,
       "classes": 0,
       "is_package": false,
-      "fan_in": 3,
+      "fan_in": 4,
       "fan_out": 1,
       "external_deps": [
         "__future__",
@@ -1472,12 +1492,12 @@
       "id": "server",
       "path": "server.py",
       "layer": "other",
-      "loc": 734,
+      "loc": 749,
       "functions": 29,
       "classes": 0,
       "is_package": false,
       "fan_in": 1,
-      "fan_out": 29,
+      "fan_out": 30,
       "external_deps": [
         "app",
         "flask",
@@ -1572,6 +1592,16 @@
       "kind": "runtime"
     },
     {
+      "source": "app.ai.model_catalog",
+      "target": "app.core.redaction",
+      "kind": "runtime"
+    },
+    {
+      "source": "app.ai.providers.base",
+      "target": "app.ai.model_catalog",
+      "kind": "runtime"
+    },
+    {
       "source": "app.ai.providers.base",
       "target": "app.core.redaction",
       "kind": "import"
@@ -1588,6 +1618,11 @@
     },
     {
       "source": "app.ai.providers.gemini",
+      "target": "app.ai.model_catalog",
+      "kind": "import"
+    },
+    {
+      "source": "app.ai.providers.gemini",
       "target": "app.ai.providers.base",
       "kind": "import"
     },
@@ -1599,6 +1634,11 @@
     {
       "source": "app.ai.providers.groq",
       "target": "app.ai.circuit_breaker",
+      "kind": "import"
+    },
+    {
+      "source": "app.ai.providers.groq",
+      "target": "app.ai.model_catalog",
       "kind": "import"
     },
     {
@@ -1630,6 +1670,11 @@
       "source": "app.ai.providers.openrouter",
       "target": "app.ai.circuit_breaker",
       "kind": "import"
+    },
+    {
+      "source": "app.ai.providers.openrouter",
+      "target": "app.ai.model_catalog",
+      "kind": "runtime"
     },
     {
       "source": "app.ai.providers.openrouter",
@@ -2753,6 +2798,11 @@
     },
     {
       "source": "server",
+      "target": "app.ai.model_catalog",
+      "kind": "runtime"
+    },
+    {
+      "source": "server",
       "target": "app.ai.router",
       "kind": "runtime"
     },
@@ -2903,9 +2953,9 @@
     }
   ],
   "stats": {
-    "modules": 91,
-    "edges": 278,
-    "total_loc": 20353,
+    "modules": 92,
+    "edges": 284,
+    "total_loc": 20847,
     "layers": [
       "ai",
       "core",
@@ -2955,28 +3005,28 @@
         "fan_out": 1
       },
       {
+        "id": "app.ai.providers.base",
+        "loc": 348,
+        "fan_in": 7,
+        "fan_out": 3
+      },
+      {
         "id": "app.core.webhook_security",
         "loc": 474,
         "fan_in": 4,
         "fan_out": 1
       },
       {
-        "id": "app.ai.providers.base",
-        "loc": 294,
-        "fan_in": 7,
-        "fan_out": 2
+        "id": "app.ai.model_catalog",
+        "loc": 356,
+        "fan_in": 5,
+        "fan_out": 1
       },
       {
         "id": "app.ai.circuit_breaker",
         "loc": 144,
         "fan_in": 13,
         "fan_out": 1
-      },
-      {
-        "id": "app.intelligence.memory",
-        "loc": 328,
-        "fan_in": 5,
-        "fan_out": 2
       }
     ],
     "orphans": []

--- a/evals/run.py
+++ b/evals/run.py
@@ -65,6 +65,18 @@ def configured_models() -> list[str]:
     ]
 
 
+def _inventory_block() -> str:
+    """What every configured provider serves, and what this deployment would
+    pick from it. Never raises: a preflight that dies reporting is worse than
+    one that reports nothing."""
+    try:
+        from app.ai.model_catalog import format_inventory
+
+        return "\n-- provider catalogue --\n" + format_inventory()
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        return f"\n-- provider catalogue unavailable: {type(exc).__name__} --"
+
+
 def check_configured_models(key: str) -> tuple[bool, str]:
     """
     (ok, human-readable detail) — does the provider still serve our models?
@@ -100,7 +112,11 @@ def check_configured_models(key: str) -> tuple[bool, str]:
 
     missing = [m for m in wanted if m not in available]
     if not missing:
-        return True, f"Model check: {', '.join(wanted)} — all available."
+        # The inventory is printed on success too. Only printing it on failure
+        # meant the one moment an operator could see what to switch TO was the
+        # moment everything was already broken -- and choosing a replacement is
+        # exactly what you want to do calmly, before the id you use is retired.
+        return True, f"Model check: {', '.join(wanted)} — all available.\n{_inventory_block()}"
 
     listing = "\n".join(f"    {m}" for m in available if m)
     if len(missing) == len(wanted):

--- a/server.py
+++ b/server.py
@@ -350,14 +350,25 @@ def health():
 
     llm_config_error = ""
     llm_models = {}
+    llm_substitutions = {}
     try:
         ai_status = LLMRouter().status()
         llm_config_error = ai_status.get("configuration_error", "")
         llm_models = ai_status.get("models", {})
+
+        # A model swapped in because the configured one was retired. The bot
+        # keeps working, which is the point -- but a bot answering on a model
+        # nobody chose is its own incident, so it is never silent.
+        from app.ai.model_catalog import active_substitutions
+
+        llm_substitutions = {k: v.get("to", "") for k, v in active_substitutions().items()}
     except Exception as exc:  # health must not fail on its own reporting
         log.debug(f"health.llm_status_failed: {exc}")
 
     overall = "ok" if (gh_ok and any_llm_ok and not llm_config_error) else "degraded"
+    if llm_substitutions:
+        # Answering, but on a model nobody configured. Not "ok", not an outage.
+        overall = "degraded" if overall == "ok" else overall
     if llm_config_error:
         overall = "misconfigured"
 
@@ -380,6 +391,10 @@ def health():
                 # Retrying cannot fix either, so this is reported separately
                 # from the breakers rather than folded into "degraded".
                 "llm_configuration_error": llm_config_error,
+                # Empty in a healthy deployment. Non-empty means the configured
+                # model id is gone and one from the provider's own catalogue is
+                # being used instead -- working, but not what was asked for.
+                "llm_model_substitutions": llm_substitutions,
                 "thread_pool": "saturated" if pool_saturated else "ok",
             },
             "thread_pool": pool,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import types
 import threading
 import time
 import pytest
+from unittest.mock import patch
 
 # ── Ensure project root is on sys.path ────────────────────────────────────────
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -198,6 +199,32 @@ if "structlog" not in sys.modules:
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def no_provider_catalogue_calls():
+    """
+    The unit suite must never ask a provider what it serves.
+
+    OpenRouter's catalogue needs no API key, so the moment providers learned to
+    repair a retired model id, any test feeding a 404 would reach out to
+    openrouter.ai for real. It did: CI went red on a test that passes locally
+    only because the sandbox blocks that host — a test whose result depends on
+    the network is not a test.
+
+    Off by default here, so a catalogue is something a test opts INTO by
+    patching this function (see tests/test_model_catalog.py). Substitutions are
+    process-global, so they are cleared too: one test healing a model must not
+    change the model the next test sees.
+    """
+    import app.ai.model_catalog as mc
+
+    mc.clear_cache()
+    mc.clear_substitutions()
+    with patch.object(mc, "available_models", lambda *a, **k: []):
+        yield
+    mc.clear_cache()
+    mc.clear_substitutions()
+
 
 @pytest.fixture(autouse=True)
 def clean_redis_singleton():

--- a/tests/fixtures_model_catalog.json
+++ b/tests/fixtures_model_catalog.json
@@ -1,0 +1,38 @@
+{
+  "groq": [
+    "allam-2-7b",
+    "canopylabs/orpheus-arabic-saudi",
+    "canopylabs/orpheus-v1-english",
+    "groq/compound",
+    "groq/compound-mini",
+    "meta-llama/llama-prompt-guard-2-22m",
+    "meta-llama/llama-prompt-guard-2-86m",
+    "openai/gpt-oss-120b",
+    "openai/gpt-oss-20b",
+    "openai/gpt-oss-safeguard-20b",
+    "qwen/qwen3.6-27b",
+    "qwen/qwen3.8-27b",
+    "whisper-large-v3",
+    "whisper-large-v3-turbo"
+  ],
+  "openrouter_free": [
+    "cohere/north-mini-code:free",
+    "dots-studio/dots-3-note-preview:free",
+    "google/gemma-4-26b-a4b-it:free",
+    "google/gemma-4-31b-it:free",
+    "inclusionai/ling-3.0-flash-fin:free",
+    "liquid/lfm-2.5-2.6b:free",
+    "minimax/minimax-m2.7:free",
+    "minimax/minimax-m3:free",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+    "nvidia/nemotron-3-super-120b-a12b:free",
+    "nvidia/nemotron-3-ultra-550b-a55b:free",
+    "nvidia/nemotron-3.5-content-safety:free",
+    "nvidia/nemotron-3.5-lightning:free",
+    "poolside/laguna-s-2.1:free",
+    "poolside/laguna-xs-2.1:free",
+    "thinkingmachines/inkling-small:free",
+    "thinkingmachines/inkling:free",
+    "z-ai/glm-5.2:free"
+  ]
+}

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -343,3 +343,38 @@ class TestTheProvidersActuallyRepairThemselves:
         ]
         assert result == {"ok": True}
         assert meta.error is None
+
+
+class TestTheSuiteNeverReachesAProvider:
+    """
+    OpenRouter's catalogue needs no API key, so the moment providers learned to
+    repair a retired model id, any test feeding a 404 reached openrouter.ai for
+    real. CI caught it; locally it passed only because the sandbox blocks that
+    host. A test whose result depends on the network is not a test.
+    """
+
+    def test_the_catalogue_is_stubbed_by_default(self):
+        """The autouse guard in conftest, asserted rather than assumed."""
+        assert mc.available_models("openrouter") == []
+        assert mc.available_models("groq") == []
+
+    def test_no_http_call_escapes_during_a_provider_404(self, monkeypatch):
+        import app.ai.circuit_breaker as cb
+        from app.ai.providers.groq import GroqProvider
+
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        gone = MagicMock()
+        gone.status_code = 404
+        gone.headers = {}
+        gone.json.return_value = {"error": {"code": "model_not_found"}}
+
+        with (
+            patch("requests.get") as outbound,
+            patch.object(cb, "get_breaker", return_value=breaker),
+            patch("app.ai.providers.groq.http_requests.post", return_value=gone),
+        ):
+            GroqProvider("retired", provider_key="groq_70b").call_raw("s", "u", 10, 0.2, 5)
+
+        assert not outbound.called, "a unit test reached out to a provider catalogue"

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,345 @@
+"""
+tests/test_model_catalog.py
+
+The catalogue exists because a hardcoded model id is a dated claim about
+someone else's product, and this deployment paid for that: the provider retired
+every Llama chat model, every AI command returned 404 for six days, and the fix
+was a string nobody knew to change.
+
+The fixtures in `fixtures_model_catalog.json` are the providers' REAL
+catalogues, captured from a live run on 2026-08-29 (Evals run #11). Testing
+selection against invented model lists would prove the ranking matches my
+imagination rather than the thing it has to work against.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.ai.model_catalog as mc
+
+_FIXTURES = json.loads(
+    (Path(__file__).parent / "fixtures_model_catalog.json").read_text(encoding="utf-8")
+)
+GROQ_LIVE = _FIXTURES["groq"]
+OPENROUTER_FREE_LIVE = _FIXTURES["openrouter_free"]
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    mc.clear_cache()
+    mc.clear_substitutions()
+    yield
+    mc.clear_cache()
+    mc.clear_substitutions()
+
+
+def _catalog(models, provider="groq"):
+    return patch.object(mc, "available_models", lambda p, **k: models if p == provider else [])
+
+
+class TestSelectionAgainstTheRealCatalogue:
+
+    def test_groq_picks_what_a_human_picked(self):
+        """
+        The strongest signal available that the ranking is sane: run it against
+        the live catalogue and it independently arrives at the two ids an
+        operator chose by reading the same list.
+        """
+        with _catalog(GROQ_LIVE):
+            assert mc.best_model("groq", "quality") == "openai/gpt-oss-120b"
+            assert mc.best_model("groq", "speed") == "openai/gpt-oss-20b"
+
+    def test_the_newer_version_in_a_family_wins(self):
+        """qwen3.6 and qwen3.8 are both served. Picking 3.6 would mean the
+        tie-break sorts ascending, which is how a catalogue-driven choice
+        silently rots back into an old model."""
+        remaining = [m for m in GROQ_LIVE if "gpt-oss" not in m]
+        with _catalog(remaining):
+            assert mc.best_model("groq", "quality") == "qwen/qwen3.8-27b"
+
+    def test_non_chat_models_are_never_selected(self):
+        """Whisper, TTS, prompt-guard and safeguard are all served by this
+        provider. Picking one produces a 400 that reads like an outage rather
+        than like a bad choice — the worst way to fail."""
+        never = [m for m in GROQ_LIVE if mc._EXCLUDE.search(m)]
+        assert never, "fixture should contain non-chat models"
+        with _catalog(GROQ_LIVE):
+            for tier in ("quality", "speed"):
+                assert mc.best_model("groq", tier) not in never
+
+    def test_a_narrow_model_is_the_last_resort_not_the_default(self):
+        """allam-2-7b is a real chat model, and the wrong one for reviewing
+        code in English. It should only surface when nothing else is left."""
+        with _catalog(GROQ_LIVE):
+            assert mc.best_model("groq", "quality") != "allam-2-7b"
+        with _catalog(["allam-2-7b"]):
+            assert mc.best_model("groq", "quality") == "allam-2-7b"
+
+    def test_openrouter_only_ever_picks_a_free_model(self):
+        """This is the emergency fallback. Reaching it must never start a bill."""
+        with _catalog(OPENROUTER_FREE_LIVE + ["anthropic/claude-opus-latest"], "openrouter"):
+            for tier in ("quality", "speed"):
+                assert mc.best_model("openrouter", tier).endswith(":free")
+
+    def test_openrouter_pick_matches_the_shipped_default(self):
+        """One story, not two: the static default and the catalogue's own pick
+        must agree, or the fallback silently changes model the first time the
+        catalogue is read."""
+        from app.ai.providers.openrouter import DEFAULT_MODEL
+
+        with _catalog(OPENROUTER_FREE_LIVE, "openrouter"):
+            assert mc.best_model("openrouter", "quality") == DEFAULT_MODEL
+
+    def test_the_shipped_defaults_are_actually_served(self):
+        """The bug this whole module exists for: an id in the code that the
+        provider does not serve. Checked against the live catalogues."""
+        from app.ai.providers.openrouter import DEFAULT_MODEL
+        from app.ai.router import DEFAULT_FALLBACK_MODEL, DEFAULT_PRIMARY_MODEL
+
+        assert DEFAULT_PRIMARY_MODEL in GROQ_LIVE
+        assert DEFAULT_FALLBACK_MODEL in GROQ_LIVE
+        assert DEFAULT_MODEL in OPENROUTER_FREE_LIVE
+
+
+class TestAnUnreadableCatalogueChangesNothing:
+    """
+    Every failure here must leave the caller with the id it already had. A
+    catalogue lookup that guessed on no information could take a WORKING
+    deployment down, which would be strictly worse than the bug it fixes.
+    """
+
+    def test_no_catalogue_means_no_opinion(self):
+        with _catalog([]):
+            assert mc.best_model("groq", "quality") == ""
+            assert mc.substitute("groq_70b", "groq", "quality", "anything") == ""
+
+    def test_a_network_failure_is_not_an_empty_catalogue(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        with patch("requests.get", side_effect=OSError("boom")):
+            assert mc.available_models("groq") == []
+
+    def test_a_non_200_is_not_an_empty_catalogue(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        r = MagicMock(status_code=500)
+        with patch("requests.get", return_value=r):
+            assert mc.available_models("groq") == []
+
+    def test_a_missing_key_does_not_call_out(self, monkeypatch):
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        with patch("requests.get") as get:
+            assert mc.available_models("groq") == []
+        assert not get.called, "no key means no request, not a request that fails"
+
+    def test_the_only_candidate_being_the_failed_one_yields_nothing(self):
+        with _catalog(["openai/gpt-oss-120b"]):
+            assert mc.substitute("groq_70b", "groq", "quality", "openai/gpt-oss-120b") == ""
+
+    def test_autoheal_can_be_switched_off(self, monkeypatch):
+        monkeypatch.setenv("LLM_MODEL_AUTOHEAL", "0")
+        with _catalog(GROQ_LIVE):
+            assert mc.substitute("groq_70b", "groq", "quality", "gone") == ""
+
+
+class TestSubstitutionIsRememberedAndVisible:
+
+    def test_effective_model_returns_the_substitute(self):
+        with _catalog(GROQ_LIVE):
+            mc.substitute("groq_70b", "groq", "quality", "retired-model")
+        assert mc.effective_model("groq_70b", "retired-model") == "openai/gpt-oss-120b"
+        # Untouched providers are unaffected.
+        assert mc.effective_model("groq_8b", "openai/gpt-oss-20b") == "openai/gpt-oss-20b"
+
+    def test_it_is_reported_not_silent(self):
+        with _catalog(GROQ_LIVE):
+            mc.substitute("groq_70b", "groq", "quality", "retired-model")
+        active = mc.active_substitutions()
+        assert active["groq_70b"]["from"] == "retired-model"
+        assert active["groq_70b"]["to"] == "openai/gpt-oss-120b"
+
+
+class TestOnlyAMissingModelIsRepaired:
+    """
+    Substituting a model for a rejected key would swap a precise "your key is
+    invalid" for a baffling "we quietly changed model and it still failed".
+    """
+
+    @staticmethod
+    def _resp(payload):
+        r = MagicMock()
+        r.json.return_value = payload
+        return r
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_a_credential_fault_is_never_a_model_fault(self, status):
+        from app.ai.providers.base import is_model_missing
+
+        assert not is_model_missing(self._resp({"error": {"code": "model_not_found"}}), status)
+
+    def test_404_is_a_model_fault(self):
+        from app.ai.providers.base import is_model_missing
+
+        assert is_model_missing(self._resp({}), 404)
+
+    @pytest.mark.parametrize(
+        "message",
+        ["The model does not exist", "model has been decommissioned", "No endpoints found"],
+    )
+    def test_the_body_is_read_not_just_the_status(self, message):
+        """Providers disagree about which status a retired model gets; Groq
+        answered 400 with `model_decommissioned` at one point."""
+        from app.ai.providers.base import is_model_missing
+
+        assert is_model_missing(self._resp({"error": {"message": message}}), 400)
+
+    def test_an_unrelated_400_is_left_alone(self):
+        from app.ai.providers.base import is_model_missing
+
+        assert not is_model_missing(self._resp({"error": {"message": "context too long"}}), 400)
+
+
+class TestTheProvidersActuallyRepairThemselves:
+    """
+    The end-to-end behaviour: a provider that answers "that model does not
+    exist" gets one retry on a model it does serve, and the request succeeds
+    instead of becoming a six-day outage.
+    """
+
+    @staticmethod
+    def _ok(payload=None):
+        r = MagicMock()
+        r.status_code = 200
+        r.headers = {}
+        r.json.return_value = payload or {
+            "choices": [{"message": {"content": "the answer"}}],
+            "usage": {"total_tokens": 5},
+        }
+        r.raise_for_status.return_value = None
+        return r
+
+    @staticmethod
+    def _gone(payload=None):
+        r = MagicMock()
+        r.status_code = 404
+        r.headers = {}
+        r.json.return_value = payload or {
+            "error": {"code": "model_not_found", "message": "The model does not exist"}
+        }
+        r.raise_for_status.return_value = None
+        return r
+
+    def test_groq_retries_once_on_a_served_model(self, monkeypatch):
+        import app.ai.circuit_breaker as cb
+        from app.ai.providers.groq import GroqProvider
+
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        tried = []
+
+        def post(url, headers=None, json=None, timeout=None):
+            tried.append(json["model"])
+            return self._gone() if json["model"] == "retired-model" else self._ok()
+
+        with (
+            _catalog(GROQ_LIVE),
+            patch.object(cb, "get_breaker", return_value=breaker),
+            patch("app.ai.providers.groq.http_requests.post", side_effect=post),
+        ):
+            out = GroqProvider("retired-model", provider_key="groq_70b").call_raw(
+                "s", "u", 10, 0.2, 5
+            )
+
+        assert tried == ["retired-model", "openai/gpt-oss-120b"]
+        assert out.error is None and out.text
+        # The response must name the model that actually answered, or every
+        # log line and every disclosure footer is a lie.
+        assert out.model == "openai/gpt-oss-120b"
+
+    def test_the_fallback_tier_is_replaced_with_a_cheap_model(self, monkeypatch):
+        """A substitution must stay in its tier: healing the 20B fallback onto
+        the 120B primary would quietly triple the cost of every fallback."""
+        import app.ai.circuit_breaker as cb
+        from app.ai.providers.groq import GroqProvider
+
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        tried = []
+
+        def post(url, headers=None, json=None, timeout=None):
+            tried.append(json["model"])
+            return self._gone() if json["model"] == "retired-small" else self._ok()
+
+        with (
+            _catalog(GROQ_LIVE),
+            patch.object(cb, "get_breaker", return_value=breaker),
+            patch("app.ai.providers.groq.http_requests.post", side_effect=post),
+        ):
+            GroqProvider("retired-small", provider_key="groq_8b").call_raw("s", "u", 10, 0.2, 5)
+
+        assert tried[-1] == "openai/gpt-oss-20b"
+
+    def test_a_rejected_key_is_reported_not_worked_around(self, monkeypatch):
+        import app.ai.circuit_breaker as cb
+        from app.ai.providers.base import is_configuration_error
+        from app.ai.providers.groq import GroqProvider
+
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        tried = []
+
+        def post(url, headers=None, json=None, timeout=None):
+            tried.append(json["model"])
+            r = MagicMock()
+            r.status_code = 401
+            r.headers = {}
+            r.json.return_value = {"error": {"code": "invalid_api_key"}}
+            return r
+
+        with (
+            _catalog(GROQ_LIVE),
+            patch.object(cb, "get_breaker", return_value=breaker),
+            patch("app.ai.providers.groq.http_requests.post", side_effect=post),
+        ):
+            out = GroqProvider("openai/gpt-oss-120b", provider_key="groq_70b").call_raw(
+                "s", "u", 10, 0.2, 5
+            )
+
+        assert len(tried) == 1, "a bad key must not trigger a model retry"
+        assert is_configuration_error(out.error)
+        assert "GROQ_API_KEY" in out.error
+        assert mc.active_substitutions() == {}
+
+    def test_openrouter_repairs_and_the_retry_uses_the_new_model(self, monkeypatch):
+        """The body is built before the substitution, so a retry that forgot to
+        rebuild it would re-send the dead id and look like the fix failed."""
+        import app.ai.providers.openrouter as orx
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+        breaker = MagicMock()
+        breaker.is_available.return_value = True
+        tried = []
+
+        def post(url, headers=None, json=None, timeout=None):
+            tried.append(json["model"])
+            if json["model"] == "mistralai/mistral-7b-instruct:free":
+                return self._gone({"error": {"code": 404, "message": "No endpoints found"}})
+            return self._ok({"choices": [{"message": {"content": '{"ok": true}'}}], "usage": {}})
+
+        with (
+            _catalog(OPENROUTER_FREE_LIVE, "openrouter"),
+            patch.object(orx, "get_breaker", return_value=breaker),
+            patch.object(orx.http_requests, "post", side_effect=post),
+        ):
+            result, meta = orx.OpenRouterProvider("mistralai/mistral-7b-instruct:free").ask("s", "u")
+
+        assert tried == [
+            "mistralai/mistral-7b-instruct:free",
+            "nvidia/nemotron-3-super-120b-a12b:free",
+        ]
+        assert result == {"ok": True}
+        assert meta.error is None


### PR DESCRIPTION
## First, on CI

**CI is not failing.** Every one of the last 21 CI runs succeeded, and Evals run #10 passed. The four red runs in recent history (Evals #6–#9) all predate today's fixes and are the ones those fixes closed.

```
latest per workflow:  CI #430 success · Evals #10 success · Server Health #984 success
```

I checked before changing anything and found nothing to fix there, so this PR is about the models.

## The finding

I read each provider's live catalogue from CI rather than working from memory (Evals run #11 prints it now).

**OpenRouter's configured model does not exist.** `mistralai/mistral-7b-instruct:free` appears nowhere in the **394 models** OpenRouter currently serves, and there is no free Mistral variant at all. Every emergency fallback would have returned 404.

It was invisible because this path is only reached when the other two providers are already failing — the last resort was itself broken, and the only way to find out was to need it.

**Groq's configured models are correct and already optimal.** `openai/gpt-oss-120b` and `openai/gpt-oss-20b` are both still served, and 120b is the largest general-purpose model on the free tier:

```
groq: 14 models
  * groq/compound          * openai/gpt-oss-120b   * qwen/qwen3.6-27b
  * groq/compound-mini     * openai/gpt-oss-20b    * qwen/qwen3.8-27b
  * allam-2-7b
    (+ whisper ×2, prompt-guard ×2, gpt-oss-safeguard, orpheus ×2 — not chat models)
```

So I left them alone. The right answer to "update to the best free-tier model" here was to verify, not to churn.

**Gemini could not be verified.** No `GEMINI_API_KEY` is configured in CI, so its catalogue could not be read and I have not touched `gemini-1.5-flash`. I will not guess an id I cannot check — but the mechanism below repairs it at runtime once a key is present.

## The actual fix: stop hardcoding

Replacing one hardcoded id with a newer hardcoded id does not fix this class of bug. It resets the timer. This deployment has now been bitten twice.

A provider that says "that model does not exist" is answering a question it can also answer properly. So providers now ask: take the best served model **in the same tier**, retry once, carry on.

The tier matters — healing the 20B fallback onto the 120B primary would quietly triple the cost of every fallback.

Scoped so it can only turn a hard failure into a working request:

- **Only when the model is the problem.** A rejected key is reported exactly as before. Substituting a model there would swap "your key is invalid" for "we changed model and it still failed".
- **An unreadable catalogue changes nothing.** No catalogue, no network, no key → the caller keeps the id it had. Guessing on no information could take a *working* deployment down, which is worse than the bug.
- **Loud, never silent.** ERROR log, `/health` reports `llm_model_substitutions` and drops to `degraded`. A bot answering on a model nobody chose is its own incident.
- **`LLM_MODEL_AUTOHEAL=0`** turns it off for operators who want strictness.

Selection matches by **family pattern**, not exact id, so a version bump inside a family (`qwen3.6` → `qwen3.8`) is picked up with no code change.

## Measured, end to end

| scenario | result |
|---|---|
| primary retired | `gpt-oss-120b` → `qwen/qwen3.8-27b`, **answers** |
| fallback retired | → `gpt-oss-20b` — stays in the cheap tier |
| OpenRouter's dead default | → `nemotron-3-super-120b-a12b:free`, **answers** |
| rejected key | **1** request, no substitution, error names `GROQ_API_KEY` |
| unreadable catalogue | configured id kept, behaviour unchanged |

## On the new default

`nvidia/nemotron-3-super-120b-a12b:free` — read off the catalogue, asserted served by a test.

`super` rather than the larger `ultra` (550B) on purpose: this is the *emergency* fallback, the largest free model is also the most contended, and a 550B that queues is worth less here than a 120B that replies. `a12b` is the active parameter count of a mixture-of-experts model — 120B of knowledge at roughly 12B of latency, the right shape for a last resort.

The static default and the catalogue's own pick now agree, so there is one story rather than two.

## Type of change

- [ ] `feat` — New feature or command
- [x] `fix` — Bug fix
- [x] `docs` — Documentation only
- [x] `refactor` — Code restructure, no behavior change
- [x] `test` — Adding or updating tests
- [ ] `security` — Security fix or scanner
- [ ] `chore` — Dependencies, config, tooling

## Testing

- [x] Tests pass locally — **2220 tests**, via `./scripts/verify.sh` twice, random ordering; 92 modules, 0 cycles, 0 orphans
- [x] New functionality has tests
- [x] Tested manually — each behaviour driven through the real provider code with the live catalogues

**Selection is tested against the providers' real catalogues**, committed as `tests/fixtures_model_catalog.json` and captured from Evals run #11. Testing ranking against invented model lists would prove it matches my imagination rather than the thing it has to work against.

The strongest signal that the ranking is sane: against the live Groq list it independently arrives at the two ids a human picked by reading the same list.

Five of the new tests were run against the unfixed providers first, reverting only those source files so the tests stayed in place — all five fail there, including the one asserting the shipped defaults are actually served.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or API keys in code
- [x] Layer boundaries respected (`core/` has no side effects, etc.)
- [x] CONTRIBUTING.md guidelines followed

---
_Generated by [Claude Code](https://claude.ai/code/session_012iV5tKCGtjHZBAvnbfwM62)_