### PR TITLE
feat(doctor): the deployment can check its model ids; CI cannot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,7 @@ EVENT_QUEUE_MAX_LEN=200
 # LLM_PRIMARY_MODEL=openai/gpt-oss-120b
 # LLM_FALLBACK_MODEL=openai/gpt-oss-20b
 # LLM_GEMINI_MODEL=          # run the catalogue command below for valid ids
+# LLM_OPENROUTER_MODEL=     # the emergency fallback; must be a `:free` id
 
 # A hardcoded model id is a dated claim about someone else's product. When the
 # provider retired every Llama chat model this deployment returned 404 for six

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Done. ✈️
 | | |
 |---|---|
 | Modules | 92 |
-| Lines of code | 20,847 |
+| Lines of code | 20,977 |
 | Slash commands | 27 |
 | MCP tools | 9 |
-| Internal imports | 284 |
+| Internal imports | 286 |
 <!-- autopilot:stats:end -->
 
 <sub>Regenerated from the code by CI — see [managed README sections](#managed-readme-sections).</sub>

--- a/app/ai/providers/openrouter.py
+++ b/app/ai/providers/openrouter.py
@@ -48,15 +48,30 @@ OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b:free"
 
 
+OPENROUTER_MODEL_ENV = "LLM_OPENROUTER_MODEL"
+
+
+def openrouter_model() -> str:
+    """
+    Overridable, and read per call -- parity with the other two providers.
+
+    It was the only one of the three with no override at all, so pinning it
+    took a code change and a deploy. That is the same trap as the model id
+    itself: the setting an operator would reach for did not exist, and the
+    doctor would have reported a value nothing read.
+    """
+    return os.environ.get(OPENROUTER_MODEL_ENV, "").strip() or DEFAULT_MODEL
+
+
 class OpenRouterProvider(LLMProvider):
     """OpenRouter LLM provider — emergency fallback."""
 
     provider_key = "openrouter"
 
-    def __init__(self, model: str = DEFAULT_MODEL):
+    def __init__(self, model: str = ""):
         from app.ai.model_catalog import effective_model
 
-        self._model = effective_model("openrouter", model)
+        self._model = effective_model("openrouter", model or openrouter_model())
 
     @property
     def api_key(self) -> str:

--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -597,3 +597,92 @@ def last_model_disclosure() -> str:
 
 # Module-level singleton — thread-safe via instance locks above
 router = LLMRouter()
+
+
+def model_configuration_report() -> dict:
+    """
+    For every provider: is the configured model id one it actually serves?
+
+    Deliberately NOT part of status(), which /health calls on every probe:
+    this reads each provider's catalogue over the network, and a health check
+    that makes three outbound calls is a health check that reports the
+    network. The doctor is an explicit diagnostic, so paying for it there is
+    the right trade.
+
+    This exists because the answer depends on a key, and the key is a
+    deployment secret. CI cannot check a provider it has no credential for --
+    the Gemini catalogue was unreadable in CI for exactly that reason -- but
+    the running service holds the key and can simply ask. So the deployment
+    answers the question its own environment is the only place to answer.
+
+    Never raises: a diagnostic that fails while diagnosing is worse than one
+    that says "unknown".
+    """
+    from app.ai import model_catalog as catalog
+    from app.ai.providers.gemini import gemini_model
+    from app.ai.providers.openrouter import openrouter_model
+
+    configured = {
+        "groq": [
+            ("groq_70b", os.environ.get("LLM_PRIMARY_MODEL", DEFAULT_PRIMARY_MODEL), "quality"),
+            ("groq_8b", os.environ.get("LLM_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL), "speed"),
+        ],
+        "gemini": [("gemini", gemini_model(), "speed")],
+        "openrouter": [("openrouter", openrouter_model(), "quality")],
+    }
+
+    substitutions = catalog.active_substitutions()
+    out: dict = {"autoheal": catalog.autoheal_enabled(), "providers": {}}
+
+    for provider, entries in configured.items():
+        try:
+            served = catalog.available_models(provider)
+        except Exception:  # pragma: no cover - the report must not fail
+            served = []
+        info: dict = {
+            "catalogue_readable": bool(served),
+            "models_served": len(served),
+            "slots": [],
+        }
+        for key, model, tier in entries:
+            # "unknown" is not "missing". Reporting an unreadable catalogue as
+            # a broken model id would send an operator to change a setting
+            # that was never wrong.
+            state = "unknown" if not served else ("ok" if model in served else "retired")
+            slot = {
+                "slot": key,
+                "configured": model,
+                "state": state,
+                "substituted_to": (substitutions.get(key) or {}).get("to", ""),
+            }
+            if state == "retired":
+                slot["suggested"] = catalog.best_model(provider, tier, exclude=(model,))
+            info["slots"].append(slot)
+        out["providers"][provider] = info
+    return out
+
+
+def format_model_configuration(report: dict) -> str:
+    """The same thing as prose, for someone reading a terminal."""
+    lines = ["## Model configuration", ""]
+    if not report.get("autoheal", True):
+        lines.append("Auto-substitution is OFF (LLM_MODEL_AUTOHEAL=0). A retired id will fail.")
+        lines.append("")
+    for provider, info in (report.get("providers") or {}).items():
+        if not info.get("catalogue_readable"):
+            lines.append(
+                f"- **{provider}** — catalogue unreadable. Usually no API key set for it; "
+                f"the models below cannot be checked from here."
+            )
+        else:
+            lines.append(f"- **{provider}** — {info['models_served']} models served")
+        for slot in info.get("slots") or []:
+            mark = {"ok": "✅", "retired": "❌", "unknown": "❔"}.get(slot["state"], "❔")
+            line = f"    {mark} `{slot['slot']}` → `{slot['configured']}`"
+            if slot["state"] == "retired":
+                suggestion = slot.get("suggested") or "(nothing suitable served)"
+                line += f" — NOT served. Best available: `{suggestion}`"
+            if slot.get("substituted_to"):
+                line += f" — currently answering on `{slot['substituted_to']}`"
+            lines.append(line)
+    return "\n".join(lines)

--- a/docs/diagrams/codegraph.json
+++ b/docs/diagrams/codegraph.json
@@ -20,7 +20,7 @@
       "functions": 0,
       "classes": 0,
       "is_package": true,
-      "fan_in": 0,
+      "fan_in": 1,
       "fan_out": 0,
       "external_deps": []
     },
@@ -118,7 +118,7 @@
       "functions": 12,
       "classes": 0,
       "is_package": false,
-      "fan_in": 5,
+      "fan_in": 6,
       "fan_out": 1,
       "external_deps": [
         "app",
@@ -221,8 +221,8 @@
       "id": "app.ai.providers.openrouter",
       "path": "app/ai/providers/openrouter.py",
       "layer": "ai",
-      "loc": 312,
-      "functions": 0,
+      "loc": 327,
+      "functions": 1,
       "classes": 1,
       "is_package": false,
       "fan_in": 1,
@@ -239,12 +239,12 @@
       "id": "app.ai.router",
       "path": "app/ai/router.py",
       "layer": "ai",
-      "loc": 600,
-      "functions": 3,
+      "loc": 689,
+      "functions": 5,
       "classes": 1,
       "is_package": false,
       "fan_in": 13,
-      "fan_out": 12,
+      "fan_out": 14,
       "external_deps": [
         "app",
         "datetime",
@@ -1492,7 +1492,7 @@
       "id": "server",
       "path": "server.py",
       "layer": "other",
-      "loc": 749,
+      "loc": 775,
       "functions": 29,
       "classes": 0,
       "is_package": false,
@@ -1688,12 +1688,22 @@
     },
     {
       "source": "app.ai.router",
+      "target": "app.ai",
+      "kind": "runtime"
+    },
+    {
+      "source": "app.ai.router",
       "target": "app.ai.circuit_breaker",
       "kind": "import"
     },
     {
       "source": "app.ai.router",
       "target": "app.ai.circuit_breaker",
+      "kind": "runtime"
+    },
+    {
+      "source": "app.ai.router",
+      "target": "app.ai.model_catalog",
       "kind": "runtime"
     },
     {
@@ -2954,8 +2964,8 @@
   ],
   "stats": {
     "modules": 92,
-    "edges": 284,
-    "total_loc": 20847,
+    "edges": 286,
+    "total_loc": 20977,
     "layers": [
       "ai",
       "core",
@@ -2976,9 +2986,9 @@
       },
       {
         "id": "app.ai.router",
-        "loc": 600,
+        "loc": 689,
         "fan_in": 13,
-        "fan_out": 12
+        "fan_out": 14
       },
       {
         "id": "app.github.client",
@@ -3011,15 +3021,15 @@
         "fan_out": 3
       },
       {
-        "id": "app.core.webhook_security",
-        "loc": 474,
-        "fan_in": 4,
+        "id": "app.ai.model_catalog",
+        "loc": 356,
+        "fan_in": 6,
         "fan_out": 1
       },
       {
-        "id": "app.ai.model_catalog",
-        "loc": 356,
-        "fan_in": 5,
+        "id": "app.core.webhook_security",
+        "loc": 474,
+        "fan_in": 4,
         "fan_out": 1
       },
       {

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -124,6 +124,39 @@ else
   fi
 fi
 
+# ── Are the configured model ids ones the providers still serve? ─────────────
+#
+# Asked HERE, of the running service, because the answer needs an API key and
+# the key is a deployment secret. CI cannot check a provider it has no
+# credential for -- the Gemini catalogue is unreadable in CI for exactly that
+# reason -- but this deployment holds the key, so it can simply ask.
+step "Model ids the providers still serve"
+if [ -z "$TOKEN" ]; then
+  note "METRICS_AUTH_TOKEN not set — /setup/doctor is auth-gated, skipping"
+else
+  MODELS=$(curl -sS --max-time 45 "${auth[@]}" "$BASE_URL/setup/doctor" \
+    | jq -c '.models // empty' 2>/dev/null || echo "")
+  if [ -z "$MODELS" ]; then
+    note "this deployment predates the model report — redeploy to enable it"
+  else
+    printf '%s' "$MODELS" | jq -r '
+      .providers | to_entries[] |
+      (if .value.catalogue_readable
+         then "   \(.key): \(.value.models_served) models served"
+         else "   \(.key): catalogue unreadable (no API key set for it?)" end),
+      (.value.slots[] |
+        "     \(if .state == "ok" then "✓" elif .state == "retired" then "✗" else "?" end) " +
+        "\(.slot) → \(.configured)" +
+        (if .state == "retired" then "  RETIRED — best available: \(.suggested // "none")" else "" end) +
+        (if (.substituted_to // "") != "" then "  (answering on \(.substituted_to))" else "" end))'
+    if printf '%s' "$MODELS" | jq -e '[.providers[].slots[] | select(.state == "retired")] | length > 0' >/dev/null 2>&1; then
+      bad "a configured model id is no longer served — see the rows marked ✗"
+    else
+      ok "every checkable model id is still served"
+    fi
+  fi
+fi
+
 # ── Verdict ──────────────────────────────────────────────────────────────────
 printf '\n'
 if [ ${#FAILED[@]} -eq 0 ]; then

--- a/server.py
+++ b/server.py
@@ -279,12 +279,33 @@ def setup_doctor():
         findings = inspect_environment()
         return [{"name": f.name, "state": f.state, "detail": f.detail} for f in findings], findings
 
+    def _models_payload():
+        """
+        Whether each configured model id is one the provider still serves.
+
+        Answered HERE rather than in CI because the answer needs a key, and
+        the key is a deployment secret. CI could not check Gemini for exactly
+        that reason. The running service holds the key, so it can just ask.
+
+        Never raises: a diagnostic that dies while diagnosing is worse than
+        one that says "unknown".
+        """
+        try:
+            from app.ai.router import format_model_configuration, model_configuration_report
+
+            report = model_configuration_report()
+            return report, format_model_configuration(report)
+        except Exception as exc:
+            log.debug(f"doctor.model_report_failed: {exc}")
+            return {"error": type(exc).__name__}, ""
+
     # The deployment settings need neither a repo nor a token, and they are
     # most useful precisely when those are wrong. So answer with them rather
     # than refusing outright — a diagnostic that requires you to already have
     # the working configuration is not much of a diagnostic.
     if not repo or "/" not in repo or not raw_id.isdigit():
         env_json, findings = _env_payload()
+        models_json, models_md = _models_payload()
         return jsonify(
             {
                 "error": "repo and installation_id are required to probe permissions",
@@ -295,11 +316,15 @@ def setup_doctor():
                     "webhook delivery."
                 ),
                 "environment": env_json,
-                "report_markdown": format_environment_report(findings),
+                "models": models_json,
+                "report_markdown": format_environment_report(findings)
+                + ("\n\n" + models_md if models_md else ""),
             }
         ), 400
 
     result = diagnose(repo, int(raw_id), actor=(request.args.get("actor") or "").strip())
+    # Once: each call reads three provider catalogues over the network.
+    models_json, models_md = _models_payload()
     payload = {
         "repo": result.repo,
         "installation_id": result.installation_id,
@@ -318,7 +343,8 @@ def setup_doctor():
             for p in result.probes
         ],
         "environment": _env_payload()[0],
-        "report_markdown": format_report(result),
+        "models": models_json,
+        "report_markdown": format_report(result) + ("\n\n" + models_md if models_md else ""),
     }
     return jsonify(payload), 200 if result.healthy else 207
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -378,3 +378,119 @@ class TestTheSuiteNeverReachesAProvider:
             GroqProvider("retired", provider_key="groq_70b").call_raw("s", "u", 10, 0.2, 5)
 
         assert not outbound.called, "a unit test reached out to a provider catalogue"
+
+
+class TestTheDeploymentCanAnswerWhatCiCannot:
+    """
+    Whether a configured model id is still served depends on an API key, and
+    the key is a deployment secret. CI could not check Gemini for exactly that
+    reason — the catalogue came back "GEMINI_API_KEY not set".
+
+    The running service holds the key, so the doctor asks on its behalf. These
+    tests pin the states, because the dangerous one is reporting a model as
+    RETIRED when the truth is that we could not look.
+    """
+
+    GEMINI_SERVED = ["gemini-flash-latest", "gemini-pro-latest", "text-embedding-004"]
+
+    def _served(self, gemini=None):
+        table = {
+            "groq": GROQ_LIVE,
+            "openrouter": OPENROUTER_FREE_LIVE,
+            "gemini": GEMINI_SERVED_DEFAULT if gemini is None else gemini,
+        }
+        return lambda p, **k: table.get(p, [])
+
+    def test_a_served_id_reads_ok(self):
+        from app.ai.router import model_configuration_report
+
+        with patch.object(mc, "available_models", self._served()):
+            report = model_configuration_report()
+        groq = {s["slot"]: s for s in report["providers"]["groq"]["slots"]}
+        assert groq["groq_70b"]["state"] == "ok"
+        assert groq["groq_8b"]["state"] == "ok"
+
+    def test_a_retired_id_is_named_with_a_replacement(self, monkeypatch):
+        from app.ai.router import model_configuration_report
+
+        monkeypatch.setenv("LLM_GEMINI_MODEL", "gemini-1.5-flash")
+        with patch.object(mc, "available_models", self._served()):
+            report = model_configuration_report()
+        slot = report["providers"]["gemini"]["slots"][0]
+        assert slot["state"] == "retired"
+        assert slot["configured"] == "gemini-1.5-flash"
+        assert slot["suggested"] in self.GEMINI_SERVED
+
+    def test_an_unreadable_catalogue_is_unknown_not_retired(self):
+        """
+        The mistake that matters. Reporting "your model id is wrong" when the
+        truth is "we have no key for that provider" sends an operator to
+        change a setting that was never broken.
+        """
+        from app.ai.router import model_configuration_report
+
+        with patch.object(mc, "available_models", lambda p, **k: []):
+            report = model_configuration_report()
+        for provider in report["providers"].values():
+            assert provider["catalogue_readable"] is False
+            for slot in provider["slots"]:
+                assert slot["state"] == "unknown", slot
+
+    def test_the_prose_marks_each_state_distinctly(self, monkeypatch):
+        from app.ai.router import format_model_configuration, model_configuration_report
+
+        monkeypatch.setenv("LLM_GEMINI_MODEL", "gemini-1.5-flash")
+        with patch.object(mc, "available_models", self._served()):
+            text = format_model_configuration(model_configuration_report())
+        assert "NOT served" in text
+        assert "gemini-1.5-flash" in text
+        assert "openai/gpt-oss-120b" in text
+
+    def test_it_never_raises(self):
+        from app.ai.router import format_model_configuration, model_configuration_report
+
+        with patch.object(mc, "available_models", side_effect=RuntimeError("boom")):
+            report = model_configuration_report()
+        assert format_model_configuration(report)
+
+
+GEMINI_SERVED_DEFAULT = TestTheDeploymentCanAnswerWhatCiCannot.GEMINI_SERVED
+
+
+class TestEveryProviderCanBePinned:
+    """
+    OpenRouter was the only one of the three with no model override, so
+    pinning it took a code change and a deploy — the same trap as the model id
+    itself. Worse, the doctor was about to report a value the code never read,
+    which is how this repository previously shipped a config section nothing
+    consumed.
+    """
+
+    def test_the_override_is_honoured(self, monkeypatch):
+        from app.ai.providers.openrouter import DEFAULT_MODEL, openrouter_model
+
+        assert openrouter_model() == DEFAULT_MODEL
+        monkeypatch.setenv("LLM_OPENROUTER_MODEL", "some/other:free")
+        assert openrouter_model() == "some/other:free"
+
+    def test_the_provider_uses_it(self, monkeypatch):
+        from app.ai.providers.openrouter import OpenRouterProvider
+
+        monkeypatch.setenv("LLM_OPENROUTER_MODEL", "some/other:free")
+        assert OpenRouterProvider().model_name == "some/other:free"
+
+    def test_the_doctor_reports_what_the_code_reads(self, monkeypatch):
+        """The bug this guards: a diagnostic naming a setting nothing honours."""
+        from app.ai.router import model_configuration_report
+
+        monkeypatch.setenv("LLM_OPENROUTER_MODEL", "pinned/model:free")
+        with patch.object(mc, "available_models", lambda p, **k: []):
+            report = model_configuration_report()
+        assert report["providers"]["openrouter"]["slots"][0]["configured"] == "pinned/model:free"
+
+    def test_all_three_overrides_are_documented(self):
+        """An undocumented setting is one only its author can use."""
+        env_example = (Path(__file__).parent.parent / ".env.example").read_text(encoding="utf-8")
+        for var in ("LLM_PRIMARY_MODEL", "LLM_FALLBACK_MODEL", "LLM_GEMINI_MODEL",
+                    "LLM_OPENROUTER_MODEL"):
+            assert var in env_example, f"{var} is not documented"


### PR DESCRIPTION
## The distinction this rests on

The Gemini key **is** set — in Render. The eval reads `${{ secrets.GEMINI_API_KEY }}`, which is a **GitHub Actions** secret. Those are separate stores.

That is why Evals #12 printed `gemini: — (GEMINI_API_KEY not set)` while the live bot can use Gemini perfectly well. In the same run log, `GROQ_API_KEY: ***` (masked, so set) sat next to a blank `GEMINI_API_KEY:`.

So "is `gemini-1.5-flash` still served?" is not a gap in the key. **It is a question CI is the wrong place to ask.** The running service holds the credential, so it can simply ask.

## What this adds

`/setup/doctor` now reports, per provider, whether each configured model id is one the provider still serves — and names the best replacement when it is not:

```
## Model configuration

- groq — 14 models served
    ✅ groq_70b → openai/gpt-oss-120b
    ✅ groq_8b  → openai/gpt-oss-20b
- gemini — 4 models served
    ❌ gemini → gemini-1.5-flash — NOT served. Best available: gemini-flash-latest
- openrouter — 18 models served
    ✅ openrouter → nvidia/nemotron-3-super-120b-a12b:free
```

`scripts/verify-deployment.sh` renders it, so checking is one command against the deployment.

## The state that matters is "unknown"

An unreadable catalogue is reported as **unknown**, never as retired.

Telling an operator their model id is wrong when the truth is "there is no key for that provider" sends them to change a setting that was never broken. A test pins that distinction, because it is the failure mode that would waste the most time.

Deliberately **not** part of `status()`, which `/health` calls on every probe: this reads three catalogues over the network, and a health check that makes three outbound calls is a health check that reports the network.

## One bug found while writing it

The report initially read `OPENROUTER_MODEL` — **an environment variable nothing honours.**

OpenRouter was the only one of the three providers with no model override at all, so pinning it took a code change and a deploy. And the doctor was about to report a value the code never read — the same defect as the `ai:` config section this repo removed for shipping settings nothing consumed. It would have been a diagnostic that lies.

`LLM_OPENROUTER_MODEL` is real now, documented alongside the other three, and there is a test asserting the doctor reports the value the code actually reads.

## Type of change

- [x] `feat` — New feature or command
- [x] `fix` — Bug fix
- [x] `docs` — Documentation only
- [ ] `refactor` — Code restructure, no behavior change
- [x] `test` — Adding or updating tests
- [ ] `security` — Security fix or scanner
- [ ] `chore` — Dependencies, config, tooling

## Testing

- [x] Tests pass locally — **2231 tests**, via `./scripts/verify.sh` twice, random ordering; 92 modules, 0 cycles, 0 orphans
- [x] New functionality has tests
- [x] Tested manually — all three states (`ok` / `retired` / `unknown`) driven through the real report against the providers' live catalogues as fixtures

The `retired` path is exercised with a Gemini list to prove the mechanism reports a stale id and picks a replacement from whatever the provider actually returns. That fixture is illustrative — **the point is the mechanism, not the ids**; the real answer comes from your deployment, where the key is.

## What you can do with it once merged

Against your Render deployment:

```
BASE_URL=https://<your-app>.onrender.com METRICS_AUTH_TOKEN=... ./scripts/verify-deployment.sh
```

That will say, using the key you already have, whether `gemini-1.5-flash` is still real — and if it is not, what to set `LLM_GEMINI_MODEL` to.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or API keys in code
- [x] Layer boundaries respected (`core/` has no side effects, etc.)
- [x] CONTRIBUTING.md guidelines followed

---
_Generated by [Claude Code](https://claude.ai/code/session_012iV5tKCGtjHZBAvnbfwM62)_